### PR TITLE
all: update copyright header

### DIFF
--- a/language/cc/config.go
+++ b/language/cc/config.go
@@ -1,4 +1,4 @@
-// Copyright 2025 EngFlow, Inc. All rights reserved.
+// Copyright 2025 EngFlow Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/language/cc/generate.go
+++ b/language/cc/generate.go
@@ -1,4 +1,4 @@
-// Copyright 2025 EngFlow, Inc. All rights reserved.
+// Copyright 2025 EngFlow Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/language/cc/lang.go
+++ b/language/cc/lang.go
@@ -1,4 +1,4 @@
-// Copyright 2025 EngFlow, Inc. All rights reserved.
+// Copyright 2025 EngFlow Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/language/cc/parser/parser.go
+++ b/language/cc/parser/parser.go
@@ -1,4 +1,4 @@
-// Copyright 2025 EngFlow, Inc. All rights reserved.
+// Copyright 2025 EngFlow Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/language/cc/parser/parser_test.go
+++ b/language/cc/parser/parser_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 EngFlow, Inc. All rights reserved.
+// Copyright 2025 EngFlow Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/language/cc/resolve.go
+++ b/language/cc/resolve.go
@@ -1,4 +1,4 @@
-// Copyright 2025 EngFlow, Inc. All rights reserved.
+// Copyright 2025 EngFlow Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/language/cc/source_groups.go
+++ b/language/cc/source_groups.go
@@ -1,4 +1,4 @@
-// Copyright 2025 EngFlow, Inc. All rights reserved.
+// Copyright 2025 EngFlow Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/language/cc/source_groups_test.go
+++ b/language/cc/source_groups_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 EngFlow, Inc. All rights reserved.
+// Copyright 2025 EngFlow Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/language/internal/cc/parser/parser.go
+++ b/language/internal/cc/parser/parser.go
@@ -1,4 +1,4 @@
-// Copyright 2025 EngFlow, Inc. All rights reserved.
+// Copyright 2025 EngFlow Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/language/internal/cc/parser/parser_test.go
+++ b/language/internal/cc/parser/parser_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 EngFlow, Inc. All rights reserved.
+// Copyright 2025 EngFlow Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/scripts/license_check.sh
+++ b/scripts/license_check.sh
@@ -10,7 +10,7 @@ IGNORE_PATHS=(
 EXTS=(".go")
 
 HEADER=$(cat <<EOF
-// Copyright 2025 EngFlow, Inc. All rights reserved.
+// Copyright 2025 EngFlow Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Our legal expert informs me that "EngFlow Inc" should not have a comma.
