### PR TITLE
Remove bazel build directory symlink

### DIFF
--- a/bazel-gazelle_cpp
+++ b/bazel-gazelle_cpp
@@ -1,1 +1,0 @@
-/private/var/tmp/_bazel_wmazur/426070f44c07682290bbb2fce291b055/execroot/_main


### PR DESCRIPTION
Removes a stale symlink commited by mistake