### PR TITLE
Prevent removing unused rules generated by unmanaged rule kind

### DIFF
--- a/language/cc/generate.go
+++ b/language/cc/generate.go
@@ -33,7 +33,7 @@ import (
 func (c *ccLanguage) GenerateRules(args language.GenerateArgs) language.GenerateResult {
 	srcInfo := collectSourceInfos(args)
 	rulesInfo := extractRulesInfo(args)
-
+	
 	var result = language.GenerateResult{}
 	consumedProtoFiles := c.generateProtoLibraryRules(args, rulesInfo, &result)
 	c.generateLibraryRules(args, srcInfo, rulesInfo, consumedProtoFiles, &result)
@@ -42,8 +42,7 @@ func (c *ccLanguage) GenerateRules(args language.GenerateArgs) language.Generate
 
 	// None of the rules generated above can be empty - it's guaranteed by generating them only if sources exists
 	// However we need to inspect for existing rules that are no longer matching any files
-	result.Empty = slices.Concat(result.Empty, c.findEmptyRules(args.File, srcInfo, rulesInfo, result.Gen))
-
+	result.Empty = slices.Concat(result.Empty, c.findEmptyRules(args, srcInfo, rulesInfo, result.Gen))
 	return result
 }
 
@@ -398,7 +397,8 @@ func (c *ccLanguage) handleAmbigiousRulesAssignment(args language.GenerateArgs, 
 	}
 }
 
-func (c *ccLanguage) findEmptyRules(file *rule.File, srcInfo ccSourceInfoSet, rulesInfo rulesInfo, generatedRules []*rule.Rule) []*rule.Rule {
+func (c *ccLanguage) findEmptyRules(args language.GenerateArgs, srcInfo ccSourceInfoSet, rulesInfo rulesInfo, generatedRules []*rule.Rule) []*rule.Rule {
+	file := args.File
 	if file == nil {
 		return nil
 	}
@@ -410,6 +410,12 @@ func (c *ccLanguage) findEmptyRules(file *rule.File, srcInfo ccSourceInfoSet, ru
 		}) {
 			continue
 		}
+		
+		if !slices.Contains(knownRuleKinds, resolveCCRuleKind(r.Kind(), args.Config)) {
+			// This rule is not managed by gazelle_cc
+			continue
+		}
+		
 		sourceFiles := slices.Collect(maps.Keys(rulesInfo.ccRuleSources[r.Name()]))
 		// Check whether at least 1 file mentioned in rule definition sources is buildable (exists)
 		srcsExist := slices.ContainsFunc(sourceFiles, func(src sourceFile) bool {

--- a/language/cc/lang.go
+++ b/language/cc/lang.go
@@ -108,6 +108,7 @@ var ccRuleDefs = []string{
 	"cc_binary",
 	"cc_test",
 }
+var knownRuleKinds = append(ccRuleDefs, "cc_proto_library")
 
 func (c *ccLanguage) Loads() []rule.LoadInfo {
 	return []rule.LoadInfo{

--- a/language/cc/testdata/protobuf/service_b/BUILD.out
+++ b/language/cc/testdata/protobuf/service_b/BUILD.out
@@ -5,7 +5,7 @@ load("@rules_proto//proto:defs.bzl", "proto_library")
 # gazelle:proto file
 
 proto_library(
-    name = "model_proto",
+    name = "proto_interface",
     srcs = ["model.proto"],
     visibility = ["//visibility:public"],
     deps = ["//:root_proto"],

--- a/language/cc/testdata/protobuf/service_c/BUILD.out
+++ b/language/cc/testdata/protobuf/service_c/BUILD.out
@@ -5,6 +5,12 @@ load("@rules_proto//proto:defs.bzl", "proto_library")
 # gazelle:proto package
 
 proto_library(
+    name = "proto_interface",
+    srcs = ["model.proto"],
+    visibility = ["//visibility:public"],
+)
+
+proto_library(
     name = "service_c_proto",
     srcs = [
         "model.proto",


### PR DESCRIPTION
Fixes issue where executing `:gazelle` twice in the same repository removed generated `proto_library` targets. This lead to generating them again, but without deps assigned. 
Now we only add rules to `Empty` generation results if their kind is known and managed by gazelle_cc