### PR TITLE
[CI] Fix BCR publishing - always refer to EngFlow using capitalized name

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,5 +1,5 @@
 {
-  "homepage": "https://github.com/engflow/gazelle_cc",
+  "homepage": "https://github.com/EngFlow/gazelle_cc",
   "maintainers": [
     {
       "name": "Jay Conrod",
@@ -13,7 +13,7 @@
     }
   ],
   "repository": [
-    "github:engflow/gazelle_cc"
+    "github:EngFlow/gazelle_cc"
   ],
   "versions": [],
   "yanked_versions": {}

--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -31,11 +31,11 @@ http_archive(
     name = "gazelle_cc",
     sha256 = "${SHA}",
     strip_prefix = "${PREFIX}",
-    url = "https://github.com/engflow/gazelle_cc/releases/download/${TAG}/${ARCHIVE}",
+    url = "https://github.com/EngFlow/gazelle_cc/releases/download/${TAG}/${ARCHIVE}",
 )
 load("@gazelle_cc//:deps.bzl", "gazelle_cc_dependencies")
 gazelle_cc_dependencies()
 \`\`\`
 
-See https://github.com/engflow/gazelle_cc#installation for full setup instructions.
+See https://github.com/EngFlow/gazelle_cc#installation for full setup instructions.
 EOF

--- a/docs/workspace_setup.md
+++ b/docs/workspace_setup.md
@@ -55,7 +55,7 @@ http_archive(
     name = "gazelle_cc",
     sha256 = "8e990e454b06c529e383239e0692a1f17b003e3e7a5a0f967ee5f6aeb400105a",
     strip_prefix = "gazelle_cc-0.1.0",
-    url = "https://github.com/engflow/gazelle_cc/releases/download/v0.1.0/gazelle_cc-v0.1.0.tar.gz",
+    url = "https://github.com/EngFlow/gazelle_cc/releases/download/v0.1.0/gazelle_cc-v0.1.0.tar.gz",
     repo_mapping = {
         "@rules_go": "@io_bazel_rules_go",
         "@gazelle":  "@bazel_gazelle",


### PR DESCRIPTION
The first release to BCR failed becouse the repository pointed to `engflow/gazelle_cc` instead of `EngFlow/gazelle_cc` that was present in the artifacts. 
This PR fixes this issue in our templates and was followed by similar fix on the BCR PR side https://github.com/bazelbuild/bazel-central-registry/pull/4701/commits/7a9616322530e5b6a9ed3aff6101221f1672a47e in https://github.com/bazelbuild/bazel-central-registry/pull/4701