### PR TITLE
Correctly resolve apparent names provided by bzldep `repo_name` attribute

### DIFF
--- a/language/cc/lang.go
+++ b/language/cc/lang.go
@@ -17,6 +17,7 @@ package cc
 import (
 	_ "embed"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -118,13 +119,25 @@ var ccRuleDefs = []string{
 var knownRuleKinds = append(ccRuleDefs, "cc_proto_library")
 
 func (c *ccLanguage) Loads() []rule.LoadInfo {
+	panic("ApparentLoads should be called instead")
+}
+
+func (*ccLanguage) ApparentLoads(moduleToApparentName func(string) string) []rule.LoadInfo {
+	apparentOfDefaultName := func(moduleName, defaultName string) string {
+		if module := moduleToApparentName(moduleName); module != "" {
+			return module
+		} else {
+			return defaultName
+		}
+	}
+
 	return []rule.LoadInfo{
 		{
-			Name:    "@rules_cc//cc:defs.bzl",
+			Name:    fmt.Sprintf("@%s//cc:defs.bzl", apparentOfDefaultName("rules_cc", "rules_cc")),
 			Symbols: ccRuleDefs,
 		},
 		{
-			Name:    "@protobuf//bazel:cc_proto_library.bzl",
+			Name:    fmt.Sprintf("@%s//bazel:cc_proto_library.bzl", apparentOfDefaultName("protobuf", "com_google_protobuf")),
 			Symbols: []string{"cc_proto_library"},
 		},
 	}

--- a/language/cc/testdata/protobuf/BUILD.out
+++ b/language/cc/testdata/protobuf/BUILD.out
@@ -1,4 +1,4 @@
-load("@protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
+load("@google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
 load("@rules_cc//cc:defs.bzl", "cc_test")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 
@@ -25,6 +25,3 @@ cc_test(
         "//service_b:model_cc_proto",
     ],
 )
-
-
-

--- a/language/cc/testdata/protobuf/MODULE.bazel
+++ b/language/cc/testdata/protobuf/MODULE.bazel
@@ -1,0 +1,2 @@
+# Use custom repo name to ensure ApprentLoads works as expected
+bazel_dep(name = "protobuf", version = "", repo_name = "google_protobuf")

--- a/language/cc/testdata/protobuf/service_a/BUILD.out
+++ b/language/cc/testdata/protobuf/service_a/BUILD.out
@@ -1,4 +1,4 @@
-load("@protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
+load("@google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
 load("@rules_cc//cc:defs.bzl", "cc_test")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 
@@ -19,4 +19,3 @@ cc_test(
     srcs = ["test.cc"],
     deps = [":protobuf_service_a_cc_proto"],
 )
-

--- a/language/cc/testdata/protobuf/service_b/BUILD.out
+++ b/language/cc/testdata/protobuf/service_b/BUILD.out
@@ -50,4 +50,3 @@ cc_test(
         "//service_a:protobuf_service_a_cc_proto",
     ],
 )
-

--- a/language/cc/testdata/protobuf/service_c/BUILD.out
+++ b/language/cc/testdata/protobuf/service_c/BUILD.out
@@ -46,4 +46,3 @@ cc_test(
         "//service_a:protobuf_service_a_cc_proto",
     ],
 )
-

--- a/language/cc/testdata/protobuf_empty/BUILD.out
+++ b/language/cc/testdata/protobuf_empty/BUILD.out
@@ -6,6 +6,3 @@ cc_test(
     name = "test",
     srcs = ["test.cc"],
 )
-
-
-

--- a/language/cc/testdata/protobuf_empty/MODULE.bazel
+++ b/language/cc/testdata/protobuf_empty/MODULE.bazel
@@ -1,0 +1,1 @@
+bazel_dep(name = "protobuf", version = "")

--- a/language/cc/testdata/protobuf_filter_generated/default/BUILD.out
+++ b/language/cc/testdata/protobuf_filter_generated/default/BUILD.out
@@ -1,4 +1,4 @@
-load("@protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
+load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
 load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 


### PR DESCRIPTION
[Replace Loads with ApparentLoads to correctlly handle bzldep `repo_name` attribute. 
Also sets up default `@protobuf` repo to `@com_google_protobuf` when using workspaces