### PR TITLE
Fix bug in Set.Diff method - change the order to make it more intuitive

### DIFF
--- a/index/internal/collections/set.go
+++ b/index/internal/collections/set.go
@@ -47,18 +47,18 @@ func ToSet[T comparable](slice []T) Set[T] {
 	return set
 }
 
-// Diff returns a new Set containing elements that are in `other` but not in the current Set.
+// Diff returns a new Set containing elements that are defined in current Set but not in the other set.
 //
 // Example:
 //
 //	a := SetOf(1, 2, 3)
 //	b := SetOf(2, 3, 4)
 //	diff := a.Diff(b)
-//	=> Set[int]{4}
+//	=> Set[int]{1}
 func (s Set[T]) Diff(other Set[T]) Set[T] {
 	diff := make(Set[T])
-	for elem := range other {
-		if _, exists := s[elem]; !exists {
+	for elem := range s {
+		if _, exists := other[elem]; !exists {
 			diff.Add(elem)
 		}
 	}

--- a/index/internal/collections/set_test.go
+++ b/index/internal/collections/set_test.go
@@ -185,7 +185,7 @@ func TestSet_Diff(t *testing.T) {
 			name:     "some difference",
 			set1:     SetOf(1, 2),
 			set2:     SetOf(1, 3),
-			expected: SetOf(3),
+			expected: SetOf(2),
 		},
 	}
 


### PR DESCRIPTION
Fix to `collections.Set` API found in #66, the old behaviour was counterintuitvie