### PR TITLE
Collect `#if` conditions when parsing CC sources

### DIFF
--- a/language/cc/generate.go
+++ b/language/cc/generate.go
@@ -61,11 +61,11 @@ func extractImports(args language.GenerateArgs, files []sourceFile, sourceInfos 
 		}
 
 		sourceInfo := sourceInfos[file]
-		for _, include := range sourceInfo.Includes {
+		for _, include := range sourceInfo.CollectIncludes() {
 			*includes = append(*includes, ccInclude{
 				path:            path.Clean(include.Path),
 				fromDirectory:   args.Rel,
-				isSystemInclude: include.IsSystemInclude,
+				isSystemInclude: include.IsSystem,
 			})
 		}
 	}
@@ -449,7 +449,7 @@ func (c *ccLanguage) listRelsToIndex(args language.GenerateArgs, srcInfo ccSourc
 	relsToIndexSeen := make(map[string]struct{})
 	conf := getCcConfig(args.Config)
 	for _, si := range srcInfo.sourceInfos {
-		for _, inc := range si.Includes {
+		for _, inc := range si.CollectIncludes() {
 			dir := path.Dir(path.Clean(inc.Path))
 			if dir == "." {
 				dir = ""

--- a/language/cc/lang.go
+++ b/language/cc/lang.go
@@ -42,9 +42,9 @@ type (
 	}
 	ccInclude struct {
 		// Include path extracted from brackets or double quotes
-		rawPath string
-		// Repository root directory relative rawPath for quoted include, rawPath otherwise
-		normalizedPath string
+		path string
+		// Directory from which include is resolved
+		fromDirectory string
 		// True when include defined using brackets
 		isSystemInclude bool
 	}

--- a/language/cc/resolve.go
+++ b/language/cc/resolve.go
@@ -153,10 +153,16 @@ func (lang *ccLanguage) Resolve(c *config.Config, ix *resolve.RuleIndex, rc *rep
 	resolveIncludes := func(includes []ccInclude, attributeName string, excluded labelsSet) labelsSet {
 		deps := make(map[label.Label]struct{})
 		for _, include := range includes {
-			resolvedLabel := lang.resolveImportSpec(c, ix, from, resolve.ImportSpec{Lang: languageName, Imp: include.normalizedPath})
-			if resolvedLabel == label.NoLabel && !include.isSystemInclude {
+			var resolvedLabel = label.NoLabel
+			// 1. Try resolve using fully qualified path (repository-root relative)
+			if !include.isSystemInclude {
+				relPath := filepath.Join(include.fromDirectory, include.path)
+				resolvedLabel = lang.resolveImportSpec(c, ix, from, resolve.ImportSpec{Lang: languageName, Imp: relPath})
+			}
+			// 2. Try resolve using exact path - using the exact include directive
+			if resolvedLabel == label.NoLabel {
 				// Retry to resolve is external dependency was defined using quotes instead of braces
-				resolvedLabel = lang.resolveImportSpec(c, ix, from, resolve.ImportSpec{Lang: languageName, Imp: include.rawPath})
+				resolvedLabel = lang.resolveImportSpec(c, ix, from, resolve.ImportSpec{Lang: languageName, Imp: include.path})
 			}
 			if resolvedLabel == label.NoLabel {
 				// We typically can get here is given file does not exists or if is assigned to the resolved rule

--- a/language/cc/source_groups.go
+++ b/language/cc/source_groups.go
@@ -135,11 +135,14 @@ func buildDependencyGraph(sourceFiles []sourceFile, sourceInfos map[sourceFile]p
 		info := sourceInfos[file]
 		node := file.toGroupId()
 		graph[node].sources[file] = true
-		for _, include := range info.Includes.DoubleQuote {
+		for _, include := range info.Includes {
+			if include.IsSystemInclude {
+				continue
+			}
 			// Exclude non local headers, these are handled independently as target dependency
 			// The include can be either workspace relative or source file relative
 			for _, baseDir := range []string{"", path.Dir(file.stringValue())} {
-				dep := newSourceFile(baseDir, include)
+				dep := newSourceFile(baseDir, include.Path)
 				if _, exists := graph[dep.toGroupId()]; exists {
 					graph[node].adjacency[dep] = true
 					break

--- a/language/cc/source_groups.go
+++ b/language/cc/source_groups.go
@@ -135,8 +135,8 @@ func buildDependencyGraph(sourceFiles []sourceFile, sourceInfos map[sourceFile]p
 		info := sourceInfos[file]
 		node := file.toGroupId()
 		graph[node].sources[file] = true
-		for _, include := range info.Includes {
-			if include.IsSystemInclude {
+		for _, include := range info.CollectIncludes() {
+			if include.IsSystem {
 				continue
 			}
 			// Exclude non local headers, these are handled independently as target dependency

--- a/language/internal/cc/parser/BUILD.bazel
+++ b/language/internal/cc/parser/BUILD.bazel
@@ -2,13 +2,19 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "parser",
-    srcs = ["parser.go"],
+    srcs = [
+        "expr.go",
+        "parser.go",
+    ],
     importpath = "github.com/EngFlow/gazelle_cc/language/internal/cc/parser",
-    visibility = ["//language/cc:__pkg__"],
+    visibility = ["//language:__subpackages__"],
 )
 
 go_test(
     name = "parser_test",
     srcs = ["parser_test.go"],
     embed = [":parser"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+    ],
 )

--- a/language/internal/cc/parser/BUILD.bazel
+++ b/language/internal/cc/parser/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "parser",
     srcs = [
+        "directive.go",
         "expr.go",
         "parser.go",
     ],

--- a/language/internal/cc/parser/directive.go
+++ b/language/internal/cc/parser/directive.go
@@ -1,0 +1,105 @@
+// Copyright 2025 EngFlow Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser
+
+import (
+	"fmt"
+	"strings"
+)
+
+type (
+	// Directive represents a single preprocessor directive in a C/C++ translation unit.
+	// This may be an include, define, undefine, or conditional block (#if/#ifdef).
+	Directive interface {
+		fmt.Stringer
+	}
+	// IncludeDirective represents a `#include` or `#include_next` preprocessor directive.
+	// If IsSystem is true, angle brackets were used (<...>), otherwise quotes ("...").
+	IncludeDirective struct {
+		Path     string // Path of the included file
+		IsSystem bool   // True if system include (angle brackets), false if user include (quotes)
+
+	}
+	// DefineDirective represents a `#define` preprocessor directive, including
+	// the macro name and any replacement tokens.
+	DefineDirective struct {
+		Name   string   // Name of the macro
+		Tokens []string // 0 or more tokens representing body of the #define directive
+	}
+	// UndefineDirective represents a `#undef` preprocessor directive i.e., the removal of a macro definition.
+	UndefineDirective struct {
+		Name string // Name of the macro to undefine
+	}
+	// IfBlock represents a conditional compilation block such as #if/#ifdef/#ifndef, along with
+	// any #elif and #else branches, and their nested directives.
+	IfBlock struct {
+		Branches []ConditionalBranch // All branches of the conditional, in order
+	}
+	// ConditionalBranch represents one branch in a conditional preprocessor block.
+	// This may be #if, #elif, or #else. The Condition is nil for #else branches.
+	ConditionalBranch struct {
+		Kind      BranchKind  // The branch type (If, Elif, Else)
+		Condition Expr        // Condition to evaluate (nil for #else)
+		Body      []Directive // Nested directives inside this branch
+	}
+	// BranchKind identifies which kind of branch in a conditional preprocessor block.
+	BranchKind int
+)
+
+const (
+	IfBranch   BranchKind = iota // #if, #ifdef, #ifndef, etc.
+	ElifBranch                   // #elif, #elifdef, #elifndef
+	ElseBranch                   // #else
+)
+
+func (d IncludeDirective) String() string {
+	if d.IsSystem {
+		return fmt.Sprintf("#include <%s>", d.Path)
+	}
+	return fmt.Sprintf("#include \"%s\"", d.Path)
+}
+func (d DefineDirective) String() string {
+	return fmt.Sprintf("#define %s %s", d.Name, strings.Join(d.Tokens, " "))
+}
+func (d UndefineDirective) String() string { return fmt.Sprintf("#undef %s", d.Name) }
+func (d IfBlock) String() string {
+	var out string
+	for _, br := range d.Branches {
+		out += br.String()
+	}
+	out += "#endif\n"
+	return out
+}
+
+func (b ConditionalBranch) String() string {
+	var prefix string
+	switch b.Kind {
+	case IfBranch:
+		prefix = "#if"
+	case ElifBranch:
+		prefix = "#elif"
+	case ElseBranch:
+		prefix = "#else"
+	}
+	var cond string
+	if b.Condition != nil {
+		cond = " " + b.Condition.String()
+	}
+	var body string
+	for _, d := range b.Body {
+		body += d.String() + "\n"
+	}
+	return fmt.Sprintf("%s%s\n%s", prefix, cond, body)
+}

--- a/language/internal/cc/parser/expr.go
+++ b/language/internal/cc/parser/expr.go
@@ -1,0 +1,77 @@
+// Copyright 2025 EngFlow Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser
+
+import (
+	"fmt"
+	"log"
+)
+
+type (
+	// Represents AST for #if conditions allowing for their analysis and evaluation
+	Expr interface {
+		String() string
+	}
+	Defined struct{ Name Ident } // defined(x)
+	Not     struct{ X Expr }
+	And     struct{ L, R Expr } //  a && b
+	Or      struct{ L, R Expr } //  a || b
+	Compare struct {            // A 'op' B
+		Left  Value
+		Op    string // "==", "!=", "<", "<=", ">", ">="
+		Right Value
+	}
+)
+
+type (
+	// Represents a values that can be part of #if expressions
+	Value interface {
+		String() string
+	}
+	// Macro definition literal, e.g. _WIN32
+	Ident string
+	// Integer value literal, e.g. 42
+	Constant int
+)
+
+func (expr Defined) String() string   { return fmt.Sprintf("defined(%s)", expr.Name) }
+func (expr Compare) String() string   { return fmt.Sprintf("%s %s %d", expr.Left, expr.Op, expr.Right) }
+func (expr Not) String() string       { return "!(" + expr.X.String() + ")" }
+func (expr And) String() string       { return expr.L.String() + " && " + expr.R.String() }
+func (expr Or) String() string        { return expr.L.String() + " || " + expr.R.String() }
+func (value Ident) String() string    { return string(value) }
+func (value Constant) String() string { return fmt.Sprintf("%d", value) }
+
+// Negates the comparsion expresson by switching the operation to opposite kind, eg. == -> !=
+func (expr Compare) Negate() Compare {
+	var newOperator string
+	switch expr.Op {
+	case "==":
+		newOperator = "!="
+	case "!=":
+		newOperator = "=="
+	case "<":
+		newOperator = ">="
+	case "<=":
+		newOperator = ">"
+	case ">":
+		newOperator = "<="
+	case ">=":
+		newOperator = "<"
+	default:
+		log.Panicf("Unknown compare operation type: %v", expr)
+	}
+	return Compare{Left: expr.Left, Op: newOperator, Right: expr.Right}
+}

--- a/language/internal/cc/parser/expr.go
+++ b/language/internal/cc/parser/expr.go
@@ -16,13 +16,12 @@ package parser
 
 import (
 	"fmt"
-	"log"
 )
 
 type (
 	// Represents AST for #if conditions allowing for their analysis and evaluation
 	Expr interface {
-		String() string
+		fmt.Stringer
 	}
 	Defined struct{ Name Ident } // defined(x)
 	Not     struct{ X Expr }
@@ -38,7 +37,7 @@ type (
 type (
 	// Represents a values that can be part of #if expressions
 	Value interface {
-		String() string
+		fmt.Stringer
 	}
 	// Macro definition literal, e.g. _WIN32
 	Ident string
@@ -47,7 +46,7 @@ type (
 )
 
 func (expr Defined) String() string   { return fmt.Sprintf("defined(%s)", expr.Name) }
-func (expr Compare) String() string   { return fmt.Sprintf("%s %s %d", expr.Left, expr.Op, expr.Right) }
+func (expr Compare) String() string   { return fmt.Sprintf("%s %s %s", expr.Left, expr.Op, expr.Right) }
 func (expr Not) String() string       { return "!(" + expr.X.String() + ")" }
 func (expr And) String() string       { return expr.L.String() + " && " + expr.R.String() }
 func (expr Or) String() string        { return expr.L.String() + " || " + expr.R.String() }
@@ -71,7 +70,7 @@ func (expr Compare) Negate() Compare {
 	case ">=":
 		newOperator = "<"
 	default:
-		log.Panicf("Unknown compare operation type: %v", expr)
+		panic("unknown compare operation type")
 	}
 	return Compare{Left: expr.Left, Op: newOperator, Right: expr.Right}
 }

--- a/language/internal/cc/parser/parser.go
+++ b/language/internal/cc/parser/parser.go
@@ -24,13 +24,16 @@ import (
 )
 
 type SourceInfo struct {
-	Includes Includes
+	Includes []Include
 	HasMain  bool
 }
 
-type Includes struct {
-	DoubleQuote []string
-	Bracket     []string
+type Include struct {
+	Path string
+	// Wheter include is included using '<path>' syntax
+	IsSystemInclude bool
+	// '#if' condition guarding the expression, used to detect platform specific dependencies
+	Condition Expr // nil -> unconditional
 }
 
 func ParseSource(input string) SourceInfo {
@@ -128,12 +131,10 @@ func extractSourceInfo(input io.Reader) SourceInfo {
 
 		if token == "#include" && scanner.Scan() {
 			include := scanner.Text()
-			if strings.ContainsAny(include, "<>") {
-				sourceInfo.Includes.Bracket = append(sourceInfo.Includes.Bracket, strings.Trim(include, "<>"))
-			} else if strings.Contains(include, "\"") {
-				sourceInfo.Includes.DoubleQuote = append(sourceInfo.Includes.DoubleQuote, strings.Trim(include, "\""))
-			}
-			continue
+			sourceInfo.Includes = append(sourceInfo.Includes, Include{
+				Path:            strings.Trim(include, "<>\""),
+				IsSystemInclude: strings.ContainsAny(include, "<>"),
+			})
 		}
 
 		if token == "main" && scanner.Scan() {

--- a/language/internal/cc/parser/parser.go
+++ b/language/internal/cc/parser/parser.go
@@ -12,13 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package parser implements a lightweight scanner / parser that extracts high-level information from a C/C++ translation unit
+// without requiring a full pre-processor or compiler front-end.  It recognises:
+//
+//   - `#include` lines (both angle-bracket and quoted form)
+//   - Conditional compilation guards formed with `#if[*]`, `#ifdef`, `#ifndef` and friends, and converts the boolean logic into an Expr AST declared in the same package.
+//   - The presence of a `main()` function – useful for distinguishing executables from libraries.
+//
+// The parser is not a complete C/C++ pre-processor – it only understands enough of the grammar to serve the purposes of gazelle_cc and deliberately ignores tokens that are irrelevant for dependency extraction.
 package parser
 
 import (
 	"bufio"
 	"bytes"
+	"fmt"
 	"io"
+	"log"
 	"os"
+	"regexp"
+	"strconv"
 	"strings"
 	"unicode"
 )
@@ -36,11 +48,12 @@ type Include struct {
 	Condition Expr // nil -> unconditional
 }
 
-func ParseSource(input string) SourceInfo {
-	reader := strings.NewReader(input)
-	return extractSourceInfo(reader)
+// ParseSource runs the extractor on an in‑memory buffer.
+func ParseSource(input string) (SourceInfo, error) {
+	return parse(strings.NewReader(input))
 }
 
+// ParseSourceFile opens `filename“ and feeds its contents to the extractor.
 func ParseSourceFile(filename string) (SourceInfo, error) {
 	file, err := os.Open(filename)
 	if err != nil {
@@ -48,7 +61,7 @@ func ParseSourceFile(filename string) (SourceInfo, error) {
 	}
 	defer file.Close()
 
-	return extractSourceInfo(file), nil
+	return parse(file)
 }
 
 func isParanthesis(char rune) bool {
@@ -60,14 +73,19 @@ func isParanthesis(char rune) bool {
 	}
 }
 
+func isEOL(char byte) bool { return char == '\n' }
+
+const EOL = "<EOL>"
+
 // bufio.SplitFunc that skips both whitespaces, line comments (//...) and block comments (/*...*/)
 // The tokenizer splits not only by whitespace seperated words but also by: parenthesis, curly/square brackets
 func tokenizer(data []byte, atEOF bool) (advance int, token []byte, err error) {
 	i := 0
 	for i < len(data) {
-		char := rune(data[i])
-		// log.Printf("i=%d / %d\n", i, len(data))
+		char := data[i]
 		switch {
+		case isEOL(char):
+			return i + 1, []byte(EOL), nil
 		// Skip line comments
 		case bytes.HasPrefix(data[i:], []byte("//")):
 			i += 2
@@ -85,17 +103,26 @@ func tokenizer(data []byte, atEOF bool) (advance int, token []byte, err error) {
 				i++
 			}
 		// Skip whitespace
-		case unicode.IsSpace(char):
+		case unicode.IsSpace(rune(char)):
 			i++
 
-		case isParanthesis(char):
+		case isParanthesis(rune(char)):
 			return i + 1, data[i : i+1], nil
+
+		case char == '!' || char == '=' || char == '<' || char == '>':
+			// two-character operator?
+			if i+1 < len(data) && data[i+1] == '=' {
+				return i + 2, data[i : i+2], nil //  "==", "!=", "<=", ">="
+			}
+			return i + 1, data[i : i+1], nil // "!", "<", ">"
 
 		default:
 			start := i
 			for i < len(data) {
 				char := rune(data[i])
-				if unicode.IsSpace(char) || isParanthesis(char) {
+				if isEOL(data[i]) ||
+					char == '!' || char == '=' || char == '<' || char == '>' ||
+					unicode.IsSpace(char) || isParanthesis(char) {
 					return i, data[start:i], nil
 				}
 				i++
@@ -110,43 +137,470 @@ func tokenizer(data []byte, atEOF bool) (advance int, token []byte, err error) {
 	return i, nil, nil
 }
 
-func extractSourceInfo(input io.Reader) SourceInfo {
-	scanner := bufio.NewScanner(input)
-	scanner.Split(tokenizer)
+type parser struct {
+	tr        *tokenReader
+	lastToken string
 
-	sourceInfo := SourceInfo{}
-	lastToken := ""
-	for scanner.Scan() {
-		prevToken := lastToken
-		token := scanner.Text()
-		lastToken = token
+	// accumulated result
+	sourceInfo SourceInfo
 
-		// merge "# include" as "#include"
-		if token == "#" && scanner.Scan() {
-			token = scanner.Text()
-			if token == "include" {
-				token = "#include"
+	// active #if/#else nesting – conjunction of these is the current guard
+	conditionStack []Expr
+	// stack of "already‑seen" branch expressions for each #if group;
+	// used to build !previous when we see #else / #elif
+	exprGroupStack [][]Expr
+}
+
+// Reads the content of input and extract CC source informations
+func parse(input io.Reader) (SourceInfo, error) {
+	p := &parser{tr: newTokenReader(input)}
+	for {
+		tok, ok := p.tr.next()
+		if !ok {
+			return p.sourceInfo, p.tr.scanner.Err()
+		}
+		prev := p.lastToken
+		p.lastToken = tok
+
+		if strings.HasPrefix(tok, "#") {
+			if err := p.parseDirective(tok); err != nil {
+				return p.sourceInfo, err
 			}
+			continue
 		}
-
-		if token == "#include" && scanner.Scan() {
-			include := scanner.Text()
-			sourceInfo.Includes = append(sourceInfo.Includes, Include{
-				Path:            strings.Trim(include, "<>\""),
-				IsSystemInclude: strings.ContainsAny(include, "<>"),
-			})
-		}
-
-		if token == "main" && scanner.Scan() {
-			// TOOD: better detection of main signature
-			// We should also check for return type aliases and check if input args
-			if scanner.Text() == "(" {
-				if prevToken == "int" {
-					sourceInfo.HasMain = true
+		if tok == "main" {
+			if next, exists := p.tr.next(); exists && next == "(" {
+				if prev == "int" {
+					p.sourceInfo.HasMain = true
 				}
-				continue
 			}
 		}
 	}
-	return sourceInfo
+}
+
+// currentGuard returns the AND‑conjunction of every active #if expression.
+func (p *parser) currentGuard() Expr {
+	if len(p.conditionStack) == 0 {
+		return nil
+	}
+	acc := p.conditionStack[0]
+	for i := 1; i < len(p.conditionStack); i++ {
+		acc = And{acc, p.conditionStack[i]}
+	}
+	return acc
+}
+func (p *parser) pushCondition(expr Expr) { p.conditionStack = append(p.conditionStack, expr) }
+func (p *parser) popCondition() bool {
+	if len(p.conditionStack) == 0 {
+		return false
+	}
+	p.conditionStack = p.conditionStack[:len(p.conditionStack)-1]
+	return true
+}
+
+func (p *parser) currentGroup() []Expr {
+	if len(p.exprGroupStack) == 0 {
+		return nil
+	}
+	return p.exprGroupStack[len(p.exprGroupStack)-1]
+}
+func (p *parser) pushNewGroup(expr Expr) { p.exprGroupStack = append(p.exprGroupStack, []Expr{expr}) }
+func (p *parser) appendToCurrentGroup(expr Expr) {
+	if len(p.exprGroupStack) == 0 {
+		log.Panic("parser invariant violated: no expression group present")
+	}
+	last := &p.exprGroupStack[len(p.exprGroupStack)-1]
+	*last = append(*last, expr)
+}
+func (p *parser) popGroup() bool {
+	if len(p.exprGroupStack) == 0 {
+		return false
+	}
+	p.exprGroupStack = p.exprGroupStack[:len(p.exprGroupStack)-1]
+	return true
+}
+
+// Returns the next macro definition identifier
+func (p *parser) parseIdent() (Ident, error) {
+	token, ok := p.tr.next()
+	if !ok {
+		return "", fmt.Errorf("expected identifier, found EOF")
+	}
+	if token == "\\" { // line continuation – skip and recurse
+		return p.parseIdent()
+	}
+	return Ident(token), nil
+}
+
+func (p *parser) handleInclude() error {
+	isBracket := false
+	include, ok := p.tr.next()
+	if !ok {
+		return fmt.Errorf("unexpected EOF after #include")
+	}
+
+	// "<foo>" style – we saw the opening '<'
+	if include == "<" {
+		isBracket = true
+		include, ok = p.tr.next()
+		if !ok {
+			return fmt.Errorf("unexpected EOF in bracketed include")
+		}
+	} else if !strings.Contains(include, "\"") {
+		// Malformed input, e.g. `#include weird>`
+		isBracket = true
+	}
+
+	p.sourceInfo.Includes = append(p.sourceInfo.Includes, Include{
+		Path:            strings.Trim(include, "\""),
+		IsSystemInclude: isBracket,
+		Condition:       p.currentGuard(),
+	})
+	return nil
+}
+
+func (p *parser) handleIfdef(kind string) error {
+	ident, err := p.parseIdent()
+	if err != nil {
+		return err
+	}
+	var expr Expr = Defined{Name: ident}
+	if kind == "#ifndef" {
+		expr = Not{expr}
+	}
+	p.pushCondition(expr)
+	p.pushNewGroup(expr)
+	return nil
+}
+
+func (p *parser) handleIf() error {
+	expr, err := p.parseExpr()
+	if err != nil {
+		return err
+	}
+	p.pushCondition(expr)
+	p.pushNewGroup(expr)
+	return nil
+}
+
+func (p *parser) handleElse() {
+	cur := p.currentGroup()
+	if !p.popCondition() || cur == nil {
+		return // malformed – silently ignore
+	}
+	neg := Not{orAll(cur...)}
+	p.pushCondition(neg)
+	p.appendToCurrentGroup(neg)
+}
+
+func (p *parser) handleElif(kind string) error {
+	cur := p.currentGroup()
+	if !p.popCondition() || cur == nil {
+		return nil // malformed – silently ignore
+	}
+
+	var expr Expr
+	switch kind {
+	case "#elif":
+		var err error
+		expr, err = p.parseExpr()
+		if err != nil {
+			return err
+		}
+	case "#elifdef", "#elifndef":
+		ident, err := p.parseIdent()
+		if err != nil {
+			return err
+		}
+		expr = Defined{Name: ident}
+		if kind == "#elifndef" {
+			expr = Not{expr}
+		}
+	}
+
+	notPrev := Not{orAll(cur...)}
+	branch := And{expr, notPrev}
+	p.pushCondition(branch)
+	p.appendToCurrentGroup(expr) // add only the raw expr for future !prev
+	return nil
+}
+
+// Dispatcher for directive handlers
+func (p *parser) parseDirective(tok string) error {
+	switch tok {
+	case "#include":
+		return p.handleInclude()
+	case "#ifdef", "#ifndef":
+		return p.handleIfdef(tok)
+	case "#if":
+		return p.handleIf()
+	case "#else":
+		p.handleElse()
+	case "#elif", "#elifdef", "#elifndef":
+		return p.handleElif(tok)
+	case "#endif":
+		p.popCondition()
+		p.popGroup()
+	}
+	return nil
+}
+
+// Reads the input until end of line or until end of multi-line macro expression and parses it into Expr
+func (p *parser) parseExpr() (Expr, error) {
+	// Collect all tokens until end of line for easier processing of directive
+	// Can collect more then 1 line if ending with '\' character
+	ts := tokensStream{}
+	tr := p.tr
+collect:
+	for {
+		token, ok := p.tr.nextInternal(true)
+		if !ok {
+			return nil, fmt.Errorf("expected more tokens: %v", tr.scanner.Err())
+		}
+		switch token {
+		case "\\":
+			// Multiline expression, continue parsing next line
+			if next, ok := tr.peek(); ok && next == EOL {
+				_, _ = tr.next() // consume EOL
+				continue
+			}
+		case EOL:
+			// End of single line expression
+			break collect
+		default:
+			ts.tokens = append(ts.tokens, token)
+		}
+	}
+	parser := exprParser{ts: &ts}
+	return parser.parseOr()
+}
+
+// Parser for expressions working on already loaded and cleaned up list of tokens collected until end of possibly multine macro expression
+// Used to parse the #if <expr> conditions, handles binary (&&, ||) and unary negation (!) operators
+type exprParser struct {
+	ts *tokensStream
+}
+
+func (ep *exprParser) parseOr() (Expr, error) {
+	ts := ep.ts
+	left, err := ep.parseAnd()
+	if err != nil {
+		return nil, err
+	}
+	for ts.peek("||") {
+		_ = ts.consume("||")
+		right, err := ep.parseAnd()
+		if err != nil {
+			return nil, err
+		}
+		left = Or{left, right}
+	}
+	return left, nil
+}
+
+func (ep *exprParser) parseAnd() (Expr, error) {
+	ts := ep.ts
+	left, err := ep.parseUnary()
+	if err != nil {
+		return nil, err
+	}
+	for ts.peek("&&") {
+		_ = ts.consume("&&")
+		right, err := ep.parseUnary()
+		if err != nil {
+			return nil, err
+		}
+		left = And{left, right}
+	}
+	return left, nil
+}
+
+func (ep *exprParser) parseUnary() (Expr, error) {
+	ts := ep.ts
+	switch {
+	case ts.peek("!"):
+		_ = ts.consume("!")
+		expr, err := ep.parseUnary()
+		if err != nil {
+			return nil, err
+		}
+		return Not{expr}, nil
+
+	case ts.peek("("):
+		_ = ts.consume("(")
+		expr, err := ep.parseOr()
+		if err != nil {
+			return nil, err
+		}
+		if err := ts.consume(")"); err != nil {
+			return nil, err
+		}
+		return expr, err
+
+	case ts.peek("defined"):
+		_ = ts.consume("defined")
+		if ts.peek("(") {
+			_ = ts.consume("(")
+			name := Ident(ts.next())
+			if err := ts.consume(")"); err != nil {
+				return nil, err
+			}
+			return Defined{Name: name}, nil
+		}
+		return Defined{Name: Ident(ts.next())}, nil
+	}
+
+	token := ts.next()
+	if ts.idx < len(ts.tokens) && isBinaryCompareOperator(ts.tokens[ts.idx]) {
+		op := ts.next() // ==, !=, <, ...
+		lValue, err := interpretValue(token)
+		if err != nil {
+			return nil, err
+		}
+		rightToken := ts.next()
+		rValue, err := interpretValue(rightToken)
+		if err != nil {
+			return nil, err
+		}
+		return Compare{Left: lValue, Op: op, Right: rValue}, nil
+	}
+	return Compare{Left: Ident(token), Op: "!=", Right: Constant(0)}, nil
+}
+
+// interpretValue converts a token into either Ident or Constant.
+func interpretValue(token string) (Value, error) {
+	if macroIdentifierRegex.MatchString(token) {
+		return Ident(token), nil
+	}
+	if value, err := parseIntLiteral(token); err == nil {
+		return Constant(value), nil
+	}
+	return nil, fmt.Errorf("neither a valid identifier of integer constant")
+}
+
+func isBinaryCompareOperator(tok string) bool {
+	switch tok {
+	case "==", "!=", "<", "<=", ">", ">=":
+		return true
+	default:
+		return false
+	}
+}
+
+func parseIntLiteral(tok string) (int, error) {
+	// handle decimal, octal, hex (base 0) and ignore U/L suffixes
+	tok = strings.TrimRightFunc(tok, func(r rune) bool {
+		return r == 'u' || r == 'U' || r == 'l' || r == 'L'
+	})
+	v, err := strconv.ParseInt(tok, 0, 64)
+	return int(v), err
+}
+
+// A valid macro identifier must follow these rules:
+// * First character must be ‘_’ or a letter.
+// * Subsequent characters may be ‘_’, letters, or decimal digits.
+var macroIdentifierRegex = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+var parsableIntegerRegex = regexp.MustCompile(`^(?:0[xX][0-9a-fA-F]+|0[0-7]*|[1-9][0-9]*)(?:[uU](?:ll?|LL?)?|ll?[uU]?|LL?[uU]?)?$`)
+
+func orAll(xs ...Expr) Expr {
+	if len(xs) == 0 {
+		log.Panicf("empty orAll")
+		return nil
+	}
+	acc := xs[0]
+	for i := 1; i < len(xs); i++ {
+		acc = Or{acc, xs[i]}
+	}
+	return acc
+}
+
+// Thin wrapper around bufio.Scanner that provides `peek` and `next“ primitives while automatically skipping the ubiquitous newline marker except when explicitly requested.
+// When an algorithm needs to honour line boundaries (e.g. parseExpr) it calls nextInternal/peekInternal instead.
+type tokenReader struct {
+	scanner *bufio.Scanner
+	buf     *string // one‑token look‑ahead; nil when empty
+}
+
+func newTokenReader(r io.Reader) *tokenReader {
+	sc := bufio.NewScanner(r)
+	sc.Split(tokenizer)
+	return &tokenReader{scanner: sc}
+}
+
+// next returns the next token skipping <EOL> markers.
+func (tr *tokenReader) next() (string, bool) { return tr.nextInternal(false) }
+func (tr *tokenReader) peek() (string, bool) { return tr.peekInternal(false) }
+
+// internal helper: fetches next raw token from scanner. The bool flag identicates if data was available
+func (tr *tokenReader) fetch() (string, bool) {
+	if tr.buf != nil {
+		tok := *tr.buf
+		tr.buf = nil
+		return tok, true
+	}
+	if !tr.scanner.Scan() {
+		return "", false
+	}
+	return tr.scanner.Text(), true
+}
+
+// returns the next token, optionally filtering out EOL markers. The bool flag identicates if data was available
+func (tr *tokenReader) nextInternal(keepEOL bool) (string, bool) {
+	for {
+		tok, ok := tr.fetch()
+		if !ok {
+			return "", false
+		}
+		if tok == EOL && !keepEOL {
+			continue // skip
+		}
+		return tok, true
+	}
+}
+
+// returns the next token but does not consume the input, optionally filtering out EOL markers. The bool flag identicates if data was available
+func (tr *tokenReader) peekInternal(keepEOL bool) (string, bool) {
+	if tr.buf != nil {
+		if !keepEOL && *tr.buf == EOL {
+			return tr.next() // ensure skip semantics
+		}
+		return *tr.buf, true
+	}
+	tok, ok := tr.nextInternal(keepEOL)
+	if !ok {
+		return "", false
+	}
+	tr.buf = &tok
+	return tok, true
+}
+
+// Expression parser on already read list of tokens to simplify the logic
+type tokensStream struct {
+	tokens []string
+	idx    int
+}
+
+func (ts *tokensStream) peek(s string) bool {
+	return ts.idx < len(ts.tokens) && ts.tokens[ts.idx] == s
+}
+func (ts *tokensStream) consume(s string) error {
+	if !ts.peek(s) {
+		var next string
+		if ts.idx < len(ts.tokens) {
+			next = ts.tokens[ts.idx]
+		} else {
+			next = "<EOF>"
+		}
+		return fmt.Errorf("expected %v, got %v", s, next)
+	}
+	ts.idx++
+	return nil
+}
+func (ts *tokensStream) next() string {
+	if ts.idx >= len(ts.tokens) {
+		panic("unexpected EOL in expression")
+	}
+	val := ts.tokens[ts.idx]
+	ts.idx++
+	return val
 }

--- a/language/internal/cc/parser/parser_test.go
+++ b/language/internal/cc/parser/parser_test.go
@@ -22,7 +22,7 @@ import (
 func TestParseIncludes(t *testing.T) {
 	testCases := []struct {
 		input    string
-		expected Includes
+		expected []Include
 	}{
 		// Parses valid source code
 		{
@@ -31,9 +31,10 @@ func TestParseIncludes(t *testing.T) {
 #include "myheader.h"
 #include <math.h>
 `,
-			expected: Includes{
-				Bracket:     []string{"stdio.h", "math.h"},
-				DoubleQuote: []string{"myheader.h"},
+			expected: []Include{
+				{Path: "stdio.h", IsSystemInclude: true},
+				{Path: "myheader.h"},
+				{Path: "math.h", IsSystemInclude: true},
 			},
 		},
 		{
@@ -44,9 +45,11 @@ func TestParseIncludes(t *testing.T) {
 #include <math.h
 #include exception>
 `,
-			expected: Includes{
-				Bracket:     []string{"math.h", "exception"},
-				DoubleQuote: []string{"stdio.h", "stdlib.h"},
+			expected: []Include{
+				{Path: "stdio.h"},
+				{Path: "stdlib.h"},
+				{Path: "math.h", IsSystemInclude: true},
+				{Path: "exception", IsSystemInclude: true},
 			},
 		},
 	}
@@ -77,7 +80,7 @@ func TestParseSourceHasMain(t *testing.T) {
 				void my_function() {  // Not main
 						int x = 5;
 				}
-		
+
 				int main() {
 						return 0;
 				}

--- a/language/internal/cc/parser/parser_test.go
+++ b/language/internal/cc/parser/parser_test.go
@@ -17,6 +17,8 @@ package parser
 import (
 	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestParseIncludes(t *testing.T) {
@@ -55,10 +57,411 @@ func TestParseIncludes(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		result := ParseSource(tc.input).Includes
-		if fmt.Sprintf("%v", result) != fmt.Sprintf("%v", tc.expected) {
-			t.Errorf("For input: %q, expected %+v, but got %+v", tc.input, tc.expected, result)
+		result, err := ParseSource(tc.input)
+		if err != nil {
+			t.Errorf("Failed to parse %q, reason: %v", tc.input, err)
 		}
+		includes := result.Includes
+		if fmt.Sprintf("%v", includes) != fmt.Sprintf("%v", tc.expected) {
+			t.Errorf("For input: %q, expected %+v, but got %+v", tc.input, tc.expected, includes)
+		}
+	}
+}
+
+func TestParseConditionalIncludes(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected SourceInfo
+	}{
+		// ifdef syntax
+		{
+			input: `
+#include "common.h"
+#ifdef _WIN32
+#include <windows.h>
+#elifdef \ 
+	__APPLE__
+#include <unistd.h>
+#elifndef __linux__
+#include <fcntl.h>
+#else
+#include "other.h"
+#endif
+#include "last.h"
+`,
+			expected: SourceInfo{
+				Includes: []Include{
+					{Path: "common.h"},
+					{Path: "windows.h", IsSystemInclude: true, Condition: Defined{Ident("_WIN32")}},
+					{Path: "unistd.h", IsSystemInclude: true, Condition: And{
+						Defined{Ident("__APPLE__")},
+						Not{Defined{Ident("_WIN32")}},
+					}},
+					{Path: "fcntl.h", IsSystemInclude: true, Condition: And{
+						Not{Defined{Ident("__linux__")}},
+						Not{Or{Defined{Ident("_WIN32")}, Defined{Ident("__APPLE__")}}},
+					}},
+					{Path: "other.h", Condition: Not{
+						Or{
+							Or{
+								Defined{Ident("_WIN32")},
+								Defined{Ident("__APPLE__")},
+							},
+							Not{Defined{Ident("__linux__")}},
+						}}},
+					{Path: "last.h"},
+				},
+			},
+		},
+		// if defined syntax
+		{
+			input: `
+#if defined _WIN32
+#include "windows.h"
+#elif defined ( __APPLE__ )
+#include "unistd.h"
+#elif ! \
+	defined(\
+	__linux__)
+#include "fcntl.h"
+#else 
+#include "other.h"
+#endif
+`,
+			expected: SourceInfo{
+				Includes: []Include{
+					{Path: "windows.h", Condition: Defined{Ident("_WIN32")}},
+					{Path: "unistd.h", Condition: And{
+						Defined{Ident("__APPLE__")},
+						Not{Defined{Ident("_WIN32")}},
+					}},
+					{Path: "fcntl.h", Condition: And{
+						Not{Defined{Ident("__linux__")}},
+						Not{Or{Defined{Ident("_WIN32")}, Defined{Ident("__APPLE__")}}},
+					}},
+					{Path: "other.h", Condition: Not{
+						Or{
+							Or{
+								Defined{Ident("_WIN32")},
+								Defined{Ident("__APPLE__")},
+							},
+							Not{Defined{Ident("__linux__")}},
+						}}},
+				},
+			},
+		},
+		{
+			// complex boolean expression
+			input: `
+#if (defined(_WIN32) && defined(ENABLE_GUI)) || defined(__ANDROID__)
+#include "ui.h"
+#elif defined(_WIN32)
+#include "cli.h"
+#endif
+`,
+			expected: SourceInfo{
+				Includes: []Include{
+					{
+						Path: "ui.h",
+						Condition: Or{
+							And{
+								Defined{Name: "_WIN32"},
+								Defined{Name: "ENABLE_GUI"},
+							},
+							Defined{Name: "__ANDROID__"},
+						},
+					},
+					{
+						Path: "cli.h",
+						Condition: And{
+							Defined{Name: "_WIN32"},
+							Not{
+								Or{
+									And{
+										Defined{Name: "_WIN32"},
+										Defined{Name: "ENABLE_GUI"},
+									},
+									Defined{Name: "__ANDROID__"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			// multiline directive with continuations
+			input: `
+#if defined(_WIN32) && \
+    !defined(DISABLE_FEATURE) || \
+    (defined(__APPLE__) && defined(ENABLE_COCOA))
+#include "feature.h"
+#else
+#include "nofeature.h"
+#endif
+`,
+			expected: SourceInfo{
+				Includes: []Include{
+					{
+						Path: "feature.h",
+						Condition: Or{
+							And{
+								Defined{Name: "_WIN32"},
+								Not{Defined{Name: "DISABLE_FEATURE"}},
+							},
+							And{
+								Defined{Name: "__APPLE__"},
+								Defined{Name: "ENABLE_COCOA"},
+							},
+						},
+					},
+					{
+						Path: "nofeature.h",
+						Condition: Not{
+							Or{
+								And{
+									Defined{Name: "_WIN32"},
+									Not{Defined{Name: "DISABLE_FEATURE"}},
+								},
+								And{
+									Defined{Name: "__APPLE__"},
+									Defined{Name: "ENABLE_COCOA"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			// #if X as equivalent of X != 0
+			input: `
+#if TARGET_IOS
+  #include "ios_api.h"
+#elif !TARGET_WINDOWS 
+	#include "unix_api.h"
+#else
+	#include "windows_api.h"
+#endif
+`,
+			expected: SourceInfo{
+				Includes: []Include{
+					{
+						Path:      "ios_api.h",
+						Condition: Compare{Ident("TARGET_IOS"), "!=", Constant(0)},
+					},
+					{
+						Path: "unix_api.h",
+						Condition: And{
+							Not{Compare{Ident("TARGET_WINDOWS"), "!=", Constant(0)}},
+							Not{Compare{Ident("TARGET_IOS"), "!=", Constant(0)}},
+						},
+					},
+					{
+						Path: "windows_api.h",
+						Condition: Not{
+							Or{
+								Compare{Ident("TARGET_IOS"), "!=", Constant(0)},
+								Not{Compare{Ident("TARGET_WINDOWS"), "!=", Constant(0)}},
+							}},
+					},
+				},
+			},
+		},
+		{
+			// simple #if / #else with comparsion operator
+			input: `
+#if __WINT_WIDTH__ >= 32
+#include "wideint.h"
+#else
+#include "narrowint.h"
+#endif
+`,
+			expected: SourceInfo{
+				Includes: []Include{
+					{
+						Path:      "wideint.h",
+						Condition: Compare{Ident("__WINT_WIDTH__"), ">=", Constant(32)},
+					},
+					{
+						Path: "narrowint.h",
+						Condition: Not{
+							Compare{Ident("__WINT_WIDTH__"), ">=", Constant(32)},
+						},
+					},
+				},
+			},
+		},
+		{
+			// simple #if / #else with comparsion operator
+			input: `
+		#if 1 == __LITTLE_ENDIAN__
+		#include "a.h"
+		#elif 0 != TARGET_IOS
+		#include "b.h"
+		#elif 32 > POINTER_SIZE
+		#include "c.h"
+		#endif
+		`,
+			expected: SourceInfo{
+				Includes: []Include{
+					{
+						Path:      "a.h",
+						Condition: Compare{Constant(1), "==", Ident("__LITTLE_ENDIAN__")},
+					},
+					{
+						Path: "b.h",
+						Condition: And{
+							Compare{Constant(0), "!=", Ident("TARGET_IOS")},
+							Not{Compare{Constant(1), "==", Ident("__LITTLE_ENDIAN__")}},
+						},
+					},
+					{
+						Path: "c.h",
+						Condition: And{
+							Compare{Constant(32), ">", Ident("POINTER_SIZE")},
+							Not{Or{
+								Compare{Constant(1), "==", Ident("__LITTLE_ENDIAN__")},
+								Compare{Constant(0), "!=", Ident("TARGET_IOS")},
+							}}},
+					},
+				},
+			},
+		},
+		{
+			// ==, >, and the automatic negations created for #elif / #else
+			input: `
+#if __ARM_ARCH == 8
+#include "armv8.h"
+#elif __ARM_ARCH > 8
+#include "armv9.h"
+#else
+#include "armlegacy.h"
+#endif
+`,
+			expected: SourceInfo{
+				Includes: []Include{
+					{
+						Path:      "armv8.h",
+						Condition: Compare{Ident("__ARM_ARCH"), "==", Constant(8)},
+					},
+					{
+						Path: "armv9.h",
+						// parser rewrites #elif into A && !previous(A)
+						Condition: And{
+							Compare{Ident("__ARM_ARCH"), ">", Constant(8)},
+							Not{Compare{Ident("__ARM_ARCH"), "==", Constant(8)}},
+						},
+					},
+					{
+						Path: "armlegacy.h",
+						// final #else → !(A || B)
+						Condition: Not{
+							Or{
+								Compare{Ident("__ARM_ARCH"), "==", Constant(8)},
+								Compare{Ident("__ARM_ARCH"), ">", Constant(8)},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			// nested #if / #else blocks – 3 levels deep
+			input: `
+				#if defined FOO
+					#include "foo.h"
+						#if defined(BAR)
+							#include "bar.h"
+							#ifdef BAZ
+								#include "baz.h"
+							#elifdef QUX
+								#include "qux.h"
+							#else
+								#include "nobaz.h"
+							#endif
+						#else
+							#include "nobar.h"
+						#endif
+				#else
+					#include "nofoo.h"
+				#endif
+				`,
+			expected: SourceInfo{
+				Includes: []Include{
+					{
+						Path:      "foo.h",
+						Condition: Defined{Ident("FOO")},
+					},
+					{
+						Path: "bar.h",
+						Condition: And{
+							Defined{Ident("FOO")},
+							Defined{Ident("BAR")},
+						},
+					},
+					{
+						Path: "baz.h",
+						Condition: And{
+							And{
+								Defined{Ident("FOO")},
+								Defined{Ident("BAR")},
+							},
+							Defined{Ident("BAZ")},
+						},
+					},
+					{
+						// QUX branch:  FOO && BAR && QUX && !BAZ
+						Path: "qux.h",
+						Condition: And{
+							And{ // FOO && BAR
+								Defined{Ident("FOO")},
+								Defined{Ident("BAR")},
+							},
+							And{ // QUX && !BAZ
+								Defined{Ident("QUX")},
+								Not{Defined{Ident("BAZ")}},
+							},
+						},
+					},
+					{
+						// nobaz branch: FOO && BAR && !(BAZ || QUX)
+						Path: "nobaz.h",
+						Condition: And{
+							And{ // FOO && BAR
+								Defined{Ident("FOO")},
+								Defined{Ident("BAR")},
+							},
+							Not{ // !(BAZ || QUX)
+								Or{
+									Defined{Ident("BAZ")},
+									Defined{Ident("QUX")},
+								},
+							},
+						},
+					},
+					{
+						Path: "nobar.h",
+						Condition: And{
+							Defined{Ident("FOO")},
+							Not{Defined{Ident("BAR")}},
+						},
+					},
+					{
+						Path:      "nofoo.h",
+						Condition: Not{Defined{Ident("FOO")}},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		result, err := ParseSource(tc.input)
+		if err != nil {
+			t.Errorf("Failed to parse %q, reason: %v", tc.input, err)
+		}
+		assert.Equal(t, tc.expected, result, "Input:%v", tc.input)
 	}
 }
 
@@ -143,9 +546,13 @@ func TestParseSourceHasMain(t *testing.T) {
 	}
 
 	for idx, tc := range testCases {
-		result := ParseSource(tc.input).HasMain
-		if fmt.Sprintf("%v", result) != fmt.Sprintf("%v", tc.expected) {
-			t.Errorf("For test case %d input: %q, expected %+v, but got %+v", idx, tc.input, tc.expected, result)
+		result, err := ParseSource(tc.input)
+		if err != nil {
+			t.Errorf("Failed to parse %q, reason: %v", tc.input, err)
+		}
+		hasMain := result.HasMain
+		if fmt.Sprintf("%v", hasMain) != fmt.Sprintf("%v", tc.expected) {
+			t.Errorf("For test case %d input: %q, expected %+v, but got %+v", idx, tc.input, tc.expected, hasMain)
 		}
 	}
 }

--- a/language/internal/cc/parser/parser_test.go
+++ b/language/internal/cc/parser/parser_test.go
@@ -40,18 +40,19 @@ func TestParseIncludes(t *testing.T) {
 			},
 		},
 		{
-			// Accept malformed include
+			// Ignore malformed include
 			input: `
+#include "valid.h"
 #include "stdio.h
 #include stdlib.h"
 #include <math.h
 #include exception>
+#include "multiple"quotes.h"
+#include <other_valid>
 `,
 			expected: []Include{
-				{Path: "stdio.h"},
-				{Path: "stdlib.h"},
-				{Path: "math.h", IsSystemInclude: true},
-				{Path: "exception", IsSystemInclude: true},
+				{Path: "valid.h"},
+				{Path: "other_valid", IsSystemInclude: true},
 			},
 		},
 	}

--- a/language/internal/cc/parser/parser_test.go
+++ b/language/internal/cc/parser/parser_test.go
@@ -30,7 +30,7 @@ func TestParseIncludes(t *testing.T) {
 			input: `
 #include <stdio.h>
 #include "myheader.h"
-#include <math.h>
+# include <math.h>
 `,
 			expected: []Directive{
 				IncludeDirective{Path: "stdio.h", IsSystem: true},
@@ -48,6 +48,8 @@ func TestParseIncludes(t *testing.T) {
 #include exception>
 #include "multiple"quotes.h"
 #include <other_valid>
+# 
+# unknown_directive
 `,
 			expected: []Directive{
 				IncludeDirective{Path: "valid.h"},


### PR DESCRIPTION
Extracts changes for parser and storing includes from #66  

The first commit is a small remodeling on how we store the parsed Includes - instead of having 2 lists of brack/doubleQuoated includes we have a single list of `Include` where each element can contain more information, we would use this to add additional fields later. This change adapts existing test cases and usages within the codebase. 

The second commit refactors the `parser` and ads capability of parsing the `#if` conditions as `Expr` AST - this data is not yet used, but would be used in the future. All changes are done only to the `parser.go` and by adding additional test cases to `parser_test.go`

The `Expr` types currently don't have any functionality, but it would change after introducing concept of Platforms and Macros in the follow up PR