### PR TITLE
[CI] Exclude Windows and Debian from`.bcr/presubmit.yml`

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,7 +1,7 @@
 bcr_test_module:
   module_path: "example/bzlmod"
   matrix:
-    platform: ["debian10", "macos", "ubuntu2004", "windows"]
+    platform: ["debian10", "macos", "ubuntu2004"]
     bazel: [7.x, 8.x, rolling, last_green]
   tasks:
     run_tests:

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,7 +1,7 @@
 bcr_test_module:
   module_path: "example/bzlmod"
   matrix:
-    platform: ["debian10", "macos", "ubuntu2004"]
+    platform: ["macos", "ubuntu2004"]
     bazel: [7.x, 8.x, rolling, last_green]
   tasks:
     run_tests:


### PR DESCRIPTION
We exclude Windows from being tested in BCR presubmit CI due to issues found during release 0.1.0 - https://github.com/bazelbuild/bazel-central-registry/pull/4795 

The Windows builds failed, because `shell_commands` is not available on Windows (silently skipped). Upon changing to `run_targets` as suggested by BCR maintainers the protobuf builds started to fail on all platforms - this step was required to ensure that generate targets by gazelle are correct. I was not able to reproduce these issues locally. 
The logs showed also that default C++ toolchain on Windows  was using incompatible version of C++ - gtest required at least C++ 17.  

We also remove Debian because we don't test it in our own CI and I don't have any machine with this system to test locally.