### PR TITLE
parser: parse /#\s+include/

### DIFF
--- a/language/internal/cc/parser/parser.go
+++ b/language/internal/cc/parser/parser.go
@@ -118,6 +118,14 @@ func extractSourceInfo(input io.Reader) SourceInfo {
 		token := scanner.Text()
 		lastToken = token
 
+		// merge "# include" as "#include"
+		if token == "#" && scanner.Scan() {
+			token = scanner.Text()
+			if token == "include" {
+				token = "#include"
+			}
+		}
+
 		if token == "#include" && scanner.Scan() {
 			include := scanner.Text()
 			if strings.ContainsAny(include, "<>") {


### PR DESCRIPTION
If the parser see "# include", just parse as "#include"