### PR TITLE
[parser] Handle function macro calls and improve #define directive representation

### DIFF
--- a/language/internal/cc/parser/directive.go
+++ b/language/internal/cc/parser/directive.go
@@ -35,8 +35,9 @@ type (
 	// DefineDirective represents a `#define` preprocessor directive, including
 	// the macro name and any replacement tokens.
 	DefineDirective struct {
-		Name   string   // Name of the macro
-		Tokens []string // 0 or more tokens representing body of the #define directive
+		Name string   // Name of the macro
+		Args []string // 0 or more tokens representing arguments of the #define directive
+		Body []string // 0 or more tokens representing body of the #define directive
 	}
 	// UndefineDirective represents a `#undef` preprocessor directive i.e., the removal of a macro definition.
 	UndefineDirective struct {
@@ -71,7 +72,11 @@ func (d IncludeDirective) String() string {
 	return fmt.Sprintf("#include \"%s\"", d.Path)
 }
 func (d DefineDirective) String() string {
-	return fmt.Sprintf("#define %s %s", d.Name, strings.Join(d.Tokens, " "))
+	argsString := ""
+	if len(d.Args) >= 0 {
+		argsString = strings.Join(d.Args, ", ")
+	}
+	return fmt.Sprintf("#define %s(%s) %s", d.Name, argsString, strings.Join(d.Body, " "))
 }
 func (d UndefineDirective) String() string { return fmt.Sprintf("#undef %s", d.Name) }
 func (d IfBlock) String() string {

--- a/language/internal/cc/parser/directive.go
+++ b/language/internal/cc/parser/directive.go
@@ -74,9 +74,9 @@ func (d IncludeDirective) String() string {
 func (d DefineDirective) String() string {
 	argsString := ""
 	if len(d.Args) >= 0 {
-		argsString = strings.Join(d.Args, ", ")
+		argsString = "(" + strings.Join(d.Args, ", ") + ")"
 	}
-	return fmt.Sprintf("#define %s(%s) %s", d.Name, argsString, strings.Join(d.Body, " "))
+	return fmt.Sprintf("#define %s%s %s", d.Name, argsString, strings.Join(d.Body, " "))
 }
 func (d UndefineDirective) String() string { return fmt.Sprintf("#undef %s", d.Name) }
 func (d IfBlock) String() string {

--- a/language/internal/cc/parser/expr.go
+++ b/language/internal/cc/parser/expr.go
@@ -16,6 +16,7 @@ package parser
 
 import (
 	"fmt"
+	"strings"
 )
 
 type (
@@ -52,6 +53,12 @@ type (
 		Op    string // Comparison operator: "==", "!=", "<", "<=", ">", ">="
 		Right Expr   // Right-hand side of the comparison
 	}
+	Apply struct {
+		// Name or macro being applied.
+		Name Ident
+		// Arguments to the function or macro,
+		Args []Expr
+	}
 )
 
 type (
@@ -65,8 +72,15 @@ type (
 	ConstantInt int
 )
 
-func (expr Defined) String() string     { return fmt.Sprintf("defined(%s)", expr.Name) }
-func (expr Compare) String() string     { return fmt.Sprintf("%s %s %s", expr.Left, expr.Op, expr.Right) }
+func (expr Defined) String() string { return fmt.Sprintf("defined(%s)", expr.Name) }
+func (expr Compare) String() string { return fmt.Sprintf("%s %s %s", expr.Left, expr.Op, expr.Right) }
+func (expr Apply) String() string {
+	argStrings := make([]string, len(expr.Args))
+	for i, arg := range expr.Args {
+		argStrings[i] = arg.String()
+	}
+	return fmt.Sprintf("%s(%s)", expr.Name, strings.Join(argStrings, ", "))
+}
 func (expr Not) String() string         { return "!(" + expr.X.String() + ")" }
 func (expr And) String() string         { return expr.L.String() + " && " + expr.R.String() }
 func (expr Or) String() string          { return expr.L.String() + " || " + expr.R.String() }

--- a/language/internal/cc/parser/parser.go
+++ b/language/internal/cc/parser/parser.go
@@ -378,7 +378,7 @@ func (p *parser) parseDirectivesUntil(shouldStop func(token string) bool) ([]Dir
 				// `# directive` syntax, read and merge with next token
 				directiveKind, err := p.nextToken()
 				if err != nil {
-					skipped, _ := p.skipLine() // skip remaining part of directive
+					skipped, _ := p.readUntilEOL() // skip remaining part of directive
 					if debug {
 						log.Printf("Failed to parse %v directive: %v, skipping tokens until end of line: %v", token, err, skipped)
 					}
@@ -389,7 +389,7 @@ func (p *parser) parseDirectivesUntil(shouldStop func(token string) bool) ([]Dir
 			}
 			directive, err := p.parseDirective(token)
 			if err != nil {
-				skipped, _ := p.skipLine() // skip remaining part of directive
+				skipped, _ := p.readUntilEOL() // skip remaining part of directive
 				if debug {
 					log.Printf("Failed to parse %v directive: %v, skipping tokens until end of line: %v", token, err, skipped)
 				}
@@ -424,8 +424,8 @@ func (p *parser) nextToken() (string, error) {
 	return token, nil
 }
 
-// skipLine skips all tokens until the end of the line, returning skipped tokens for error recovery.
-func (p *parser) skipLine() ([]string, error) {
+// readUntilEOL skips all tokens until the end of the line, returning all read tokens as a slice.
+func (p *parser) readUntilEOL() ([]string, error) {
 	tokens := []string{}
 	if p.tr.lastToken == EOL {
 		return tokens, nil

--- a/language/internal/cc/parser/parser_test.go
+++ b/language/internal/cc/parser/parser_test.go
@@ -478,7 +478,7 @@ func TestParseConditionalIncludes(t *testing.T) {
 							Kind:      IfBranch,
 							Condition: Not{Defined{Ident("FOO_H")}},
 							Body: []Directive{
-								DefineDirective{Name: "FOO_H", Tokens: []string{}},
+								DefineDirective{Name: "FOO_H", Args: []string{}, Body: []string{}},
 								IncludeDirective{Path: "bar.h"},
 								UndefineDirective{Name: "FOO_H"},
 							},
@@ -512,6 +512,38 @@ func TestParseConditionalIncludes(t *testing.T) {
 								},
 							},
 						}},
+					},
+				},
+			},
+		},
+		{
+			// Apply function-like macro
+			input: `
+			#define IS_EQUAL(a, b) ((a) == (b))
+			#if IS_EQUAL(FOO, BAR)
+				#include "foo.h"
+			#else 
+				#include "bar.h"
+			#endif
+			`,
+			expected: SourceInfo{
+				Directives: []Directive{
+					DefineDirective{Name: "IS_EQUAL", Args: []string{"a", "b"}, Body: []string{"(", "(", "a", ")", "==", "(", "b", ")", ")"}},
+					IfBlock{Branches: []ConditionalBranch{
+						{
+							Kind:      IfBranch,
+							Condition: Apply{Name: Ident("IS_EQUAL"), Args: []Expr{Ident("FOO"), Ident("BAR")}},
+							Body: []Directive{
+								IncludeDirective{Path: "foo.h"},
+							},
+						},
+						{
+							Kind: ElseBranch,
+							Body: []Directive{
+								IncludeDirective{Path: "bar.h"},
+							},
+						},
+					},
 					},
 				},
 			},

--- a/language/internal/cc/parser/parser_test.go
+++ b/language/internal/cc/parser/parser_test.go
@@ -487,6 +487,35 @@ func TestParseConditionalIncludes(t *testing.T) {
 				},
 			},
 		},
+		{
+			// Apply function-like macro
+			input: `
+			#if defined(__has_builtin)
+				#if __has_builtin(__builtin_add_overflow)
+				#endif
+			#endif
+			`,
+			expected: SourceInfo{
+				Directives: []Directive{
+					IfBlock{Branches: []ConditionalBranch{
+						{
+							Kind:      IfBranch,
+							Condition: Defined{Ident("__has_builtin")},
+							Body: []Directive{
+								IfBlock{Branches: []ConditionalBranch{
+									{
+										Kind:      IfBranch,
+										Condition: Apply{Name: Ident("__has_builtin"), Args: []Expr{Ident("__builtin_add_overflow")}},
+										Body:      []Directive{},
+									},
+								},
+								},
+							},
+						}},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Fixes #78  
Parser is now able to handle function macro calls and represent them using `Expr.Apply` 
`DefineDirective` now contains explicit `Args` and `Body` variables instead of single `Tokens` to make evaluation possible in the future.