### PR TITLE
Remove cc_proto_library only when proto_library was removed

### DIFF
--- a/language/cc/generate.go
+++ b/language/cc/generate.go
@@ -425,7 +425,7 @@ func (c *ccLanguage) findEmptyRules(args language.GenerateArgs, srcInfo ccSource
 
 		if !slices.Contains(ccRuleDefs, resolveCCRuleKind(r.Kind(), args.Config)) {
 			// This rule is not managed by gazelle_cc
-			// proto_cc_library would be removed if related proto_library was removed (via args.OtherEmpty)
+			// cc_proto_library would be removed if related proto_library was removed (via args.OtherEmpty)
 			continue
 		}
 

--- a/language/cc/generate.go
+++ b/language/cc/generate.go
@@ -423,8 +423,9 @@ func (c *ccLanguage) findEmptyRules(args language.GenerateArgs, srcInfo ccSource
 			continue
 		}
 
-		if !slices.Contains(knownRuleKinds, resolveCCRuleKind(r.Kind(), args.Config)) {
+		if !slices.Contains(ccRuleDefs, resolveCCRuleKind(r.Kind(), args.Config)) {
 			// This rule is not managed by gazelle_cc
+			// proto_cc_library would be removed if related proto_library was removed (via args.OtherEmpty)
 			continue
 		}
 

--- a/language/cc/lang.go
+++ b/language/cc/lang.go
@@ -116,7 +116,6 @@ var ccRuleDefs = []string{
 	"cc_binary",
 	"cc_test",
 }
-var knownRuleKinds = append(ccRuleDefs, "cc_proto_library")
 
 func (c *ccLanguage) Loads() []rule.LoadInfo {
 	panic("ApparentLoads should be called instead")

--- a/language/cc/testdata/protobuf_empty/default/BUILD.in
+++ b/language/cc/testdata/protobuf_empty/default/BUILD.in
@@ -1,0 +1,16 @@
+load("@protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+# gazelle:proto default
+
+proto_library(
+    name = "model_proto",
+    srcs = ["model.proto"],
+    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "model_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":model_proto"],
+)

--- a/language/cc/testdata/protobuf_empty/default/BUILD.out
+++ b/language/cc/testdata/protobuf_empty/default/BUILD.out
@@ -1,0 +1,1 @@
+# gazelle:proto default

--- a/language/cc/testdata/protobuf_empty/disabled/BUILD.in
+++ b/language/cc/testdata/protobuf_empty/disabled/BUILD.in
@@ -1,0 +1,13 @@
+# gazelle:proto disable
+
+proto_library(
+    name = "model_proto",
+    srcs = ["model.proto"],
+    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "model_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":model_proto"],
+)

--- a/language/cc/testdata/protobuf_empty/disabled/BUILD.out
+++ b/language/cc/testdata/protobuf_empty/disabled/BUILD.out
@@ -1,0 +1,16 @@
+load("@protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+# gazelle:proto disable
+
+proto_library(
+    name = "model_proto",
+    srcs = ["model.proto"],
+    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "model_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":model_proto"],
+)

--- a/language/cc/testdata/protobuf_empty/disabled/README
+++ b/language/cc/testdata/protobuf_empty/disabled/README
@@ -1,0 +1,1 @@
+When disabled gazelle_cc should not remove exisitng proto rules.


### PR DESCRIPTION
Fixes #76  

When gazelle protobuf generation is disabled we should not remove the rules - these should be only removed if the upstream `language/proto` gazelle removes by adding them to `args.OtherEmpty`