### PR TITLE
Add `cc_generate_proto` to supress generation of `cc_proto_library` rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ Controls how to handle cyclic dependencies between translation units:
 - `merge`: All groups forming a cycle will be merged into a single one **(default)**
 - `warn`: Don't modify rules forming a cycle, let user handle it manually
 
+### `# gazelle:cc_generate_proto [true|false]`
+
+Specifies whether Gazelle should create `cc_proto_library` targets (default: `true`).
+It can override the broader `# gazelle:proto` setting, letting you suppress proto-target generation specifically for C/C++ rules.
+
 ### `# gazelle:cc_indexfile <path>`
 
 Loads an index file, containing a map from header include paths to Bazel labels.

--- a/language/cc/generate.go
+++ b/language/cc/generate.go
@@ -27,7 +27,6 @@ import (
 	"github.com/bazelbuild/bazel-gazelle/config"
 	"github.com/bazelbuild/bazel-gazelle/label"
 	"github.com/bazelbuild/bazel-gazelle/language"
-	"github.com/bazelbuild/bazel-gazelle/language/proto"
 	"github.com/bazelbuild/bazel-gazelle/rule"
 )
 
@@ -197,8 +196,8 @@ func (c *ccLanguage) generateTestRules(args language.GenerateArgs, srcInfo ccSou
 // Returns a set of .pb.h files that should be excluded from normal cc_library rules
 func (c *ccLanguage) generateProtoLibraryRules(args language.GenerateArgs, rulesInfo rulesInfo, result *language.GenerateResult) sourceFileSet {
 	consumedProtoFiles := make(sourceFileSet)
-	protoConfig := proto.GetProtoConfig(args.Config)
-	if protoConfig == nil || !protoConfig.Mode.ShouldGenerateRules() {
+	protoMode := getProtoMode(args.Config)
+	if !protoMode.ShouldGenerateRules() {
 		// Don't create or delete proto rules in this mode.
 		// All pb.h would be added to cc_library
 		return consumedProtoFiles

--- a/language/cc/testdata/protobuf/disabled/BUILD.in
+++ b/language/cc/testdata/protobuf/disabled/BUILD.in
@@ -1,0 +1,1 @@
+# gazelle:cc_generate_proto false

--- a/language/cc/testdata/protobuf/disabled/BUILD.out
+++ b/language/cc/testdata/protobuf/disabled/BUILD.out
@@ -1,0 +1,9 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+# gazelle:cc_generate_proto false
+
+proto_library(
+    name = "disabled_proto",
+    srcs = ["file.proto"],
+    visibility = ["//visibility:public"],
+)

--- a/language/cc/testdata/protobuf/disabled/README
+++ b/language/cc/testdata/protobuf/disabled/README
@@ -1,0 +1,1 @@
+When explicitlly disabled it should generate proto_library but not cc_proto_library

--- a/language/cc/testdata/protobuf/disabled/file.proto
+++ b/language/cc/testdata/protobuf/disabled/file.proto
@@ -1,0 +1,3 @@
+syntax = "proto3";
+
+package disabled;


### PR DESCRIPTION
Adds a switch to disable generation of proto targets only for CC language. Follows the same convention as seen in other languages, e.g. `go_generate_proto`, `java_generate_proto` directives