### PR TITLE
Fix warnings in test_e2e

### DIFF
--- a/.github/workflows/test_e2e.sh
+++ b/.github/workflows/test_e2e.sh
@@ -40,7 +40,7 @@ function testExampleBzlMod() {
 
   bazel build //...
   bazel test --test_output=errors //...
-  bazel run //proto:example 
+  bazel run //proto:example
 }
 
 function testExampleWorkspace() {
@@ -59,7 +59,7 @@ function testExampleWorkspace() {
 
   bazel build //...
   bazel test --test_output=errors //...
-  bazel run //app:main 
+  bazel run //app:main
 }
 
 testExampleBzlMod

--- a/.github/workflows/test_e2e.sh
+++ b/.github/workflows/test_e2e.sh
@@ -5,20 +5,39 @@ set -o errexit -o nounset -o pipefail
 scriptDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 rootDir=$(realpath "$scriptDir/../..")
 
+function runBazelCommandTreatingWarningsAsErrors() {
+  local CMD="$1"
+  shift
+  local OUTPUT_BASE_DIR=$(bazel info output_base)
+  local BAZEL_COMMAND_LOG_FILE="$OUTPUT_BASE_DIR/command.log"
+
+  # Disable colors and control characters to make grep work properly
+  bazel "$CMD" --color=no --curses=no "$@"
+
+  # Expect no warnings in the command output
+  local COLLECTED_WARNINGS=$(grep "^WARNING" "$BAZEL_COMMAND_LOG_FILE" || true)
+  if [[ -n "$COLLECTED_WARNINGS" ]]; then
+    echo >&2
+    echo "Unexpected warnings found:" >&2
+    echo "$COLLECTED_WARNINGS" >&2
+    exit 1
+  fi
+}
+
 function testExampleBzlMod() {
   echo "Test example/bzlmod"
   cd "$rootDir/example/bzlmod"
-  
+
   # Ensure previous BUILD files are removed
   rm -f mylib/BUILD.bazel proto/BUILD.bazel
-  
+
   # Run gazelle to generate BUILD files
-  bazel run :gazelle
-  
+  runBazelCommandTreatingWarningsAsErrors run :gazelle
+
   # Verify that BUILD files were generated
   test -f mylib/BUILD.bazel
   test -f proto/BUILD.bazel
-  
+
   bazel build //...
   bazel test --test_output=errors //...
   bazel run //proto:example 
@@ -27,17 +46,17 @@ function testExampleBzlMod() {
 function testExampleWorkspace() {
   echo "Test example/workspace"
   cd "$rootDir/example/workspace"
-  
+
   # Ensure previous BUILD files are removed
   rm -f mylib/BUILD.bazel app/BUILD.bazel
-  
+
   # Run gazelle to generate BUILD files
-  bazel run :gazelle
-  
+  runBazelCommandTreatingWarningsAsErrors run :gazelle
+
   # Verify that BUILD files were generated
   test -f mylib/BUILD.bazel
   test -f app/BUILD.bazel
-  
+
   bazel build //...
   bazel test --test_output=errors //...
   bazel run //app:main 

--- a/.github/workflows/test_e2e.sh
+++ b/.github/workflows/test_e2e.sh
@@ -6,13 +6,13 @@ scriptDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 rootDir=$(realpath "$scriptDir/../..")
 
 function runBazelCommandTreatingWarningsAsErrors() {
-  local CMD="$1"
-  shift
   local OUTPUT_BASE_DIR=$(bazel info output_base)
   local BAZEL_COMMAND_LOG_FILE="$OUTPUT_BASE_DIR/command.log"
+  local BAZEL_CMD="$1"
+  shift
 
   # Disable colors and control characters to make grep work properly
-  bazel "$CMD" --color=no --curses=no "$@"
+  command bazel "$BAZEL_CMD" --color=no --curses=no "$@"
 
   # Expect no warnings in the command output
   local COLLECTED_WARNINGS=$(grep "^WARNING" "$BAZEL_COMMAND_LOG_FILE" || true)
@@ -24,6 +24,9 @@ function runBazelCommandTreatingWarningsAsErrors() {
   fi
 }
 
+# Wrap the original bazel command
+alias bazel=runBazelCommandTreatingWarningsAsErrors
+
 function testExampleBzlMod() {
   echo "Test example/bzlmod"
   cd "$rootDir/example/bzlmod"
@@ -32,7 +35,7 @@ function testExampleBzlMod() {
   rm -f mylib/BUILD.bazel proto/BUILD.bazel
 
   # Run gazelle to generate BUILD files
-  runBazelCommandTreatingWarningsAsErrors run :gazelle
+  bazel run :gazelle
 
   # Verify that BUILD files were generated
   test -f mylib/BUILD.bazel
@@ -51,7 +54,7 @@ function testExampleWorkspace() {
   rm -f mylib/BUILD.bazel app/BUILD.bazel
 
   # Run gazelle to generate BUILD files
-  runBazelCommandTreatingWarningsAsErrors run :gazelle
+  bazel run :gazelle
 
   # Verify that BUILD files were generated
   test -f mylib/BUILD.bazel

--- a/example/bzlmod/MODULE.bazel
+++ b/example/bzlmod/MODULE.bazel
@@ -1,6 +1,6 @@
 module(name = "gazelle_cc_example")
 
-bazel_dep(name = "gazelle", version = "0.44.0")
+bazel_dep(name = "gazelle", version = "0.45.0")
 bazel_dep(name = "gazelle_cc", version = "")
 local_path_override(
     module_name = "gazelle_cc",

--- a/example/workspace/.bazelrc
+++ b/example/workspace/.bazelrc
@@ -1,0 +1,1 @@
+run --noenable_bzlmod

--- a/example/workspace/.bazelrc
+++ b/example/workspace/.bazelrc
@@ -1,1 +1,2 @@
+build --noenable_bzlmod
 run --noenable_bzlmod


### PR DESCRIPTION
The following warnings appear currently in `test-e2e` stage:

- _For repository 'gazelle', the root module requires module version gazelle@0.44.0, but got gazelle@0.45.0 in the resolved dependency graph._
- _--enable_bzlmod is set, but no MODULE.bazel file was found at the workspace root. Bazel will create an empty MODULE.bazel file._

The problems above have been fixed, and from now on, warnings will cause the test to fail.