### PR TITLE
Allow to disable dependency resolution using built-in index

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ Existing `cc_library` rules are still indexed and may be used to resolve interna
 Specifies whether Gazelle should create `cc_proto_library` targets (default: `true`).
 It can override the broader `# gazelle:proto` setting, letting you suppress proto-target generation specifically for C/C++ rules.
 
+### `# gazelle:cc_use_builtin_bzlmod_index [true|false]`
+
+Specifies wheter Gazelle should use built-in index to resolve external dependencies provided using `bazel_dep`. See [External dependencies / bazel_dep section](#bazel_dep) for more details.
+
 ### `# gazelle:cc_indexfile <path>`
 
 Loads an index file, containing a map from header include paths to Bazel labels.
@@ -186,7 +190,8 @@ The knowledge about the headers and their defining rules of external repositorie
 
 #### `bazel_dep`
 
-Gazelle C++ extension is using a [built-in index](./language/cc/bzldep-index.json) created based on all the `cc_library` rules found in [Bazel Central Registry](https://registry.bazel.build/) repositories.
+Gazelle C++ extension is using a [built-in index](./language/cc/bzldep-index.json) created based on all the `cc_library` rules found in [Bazel Central Registry](https://registry.bazel.build/) repositories. 
+The usage of built-in index can be controlled using `# gazelle:cc_use_builtin_bzlmod_index <true|false>` directive.
 
 Currently that's the recommended way of defining external dependencies
 

--- a/language/cc/resolve.go
+++ b/language/cc/resolve.go
@@ -225,7 +225,7 @@ func (lang *ccLanguage) resolveImportSpec(c *config.Config, ix *resolve.RuleInde
 		}
 	}
 
-	if label, exists := lang.bzlmodBuiltInIndex[importSpec.Imp]; exists {
+	if label, exists := lang.bzlmodBuiltInIndex[importSpec.Imp]; exists && label.Repo != c.RepoName {
 		apparantName := c.ModuleToApparentName(label.Repo)
 		// Empty apparentName means that there is no such a repository added by bazel_dep
 		if apparantName != "" {

--- a/language/cc/resolve.go
+++ b/language/cc/resolve.go
@@ -225,17 +225,19 @@ func (lang *ccLanguage) resolveImportSpec(c *config.Config, ix *resolve.RuleInde
 		}
 	}
 
-	if label, exists := lang.bzlmodBuiltInIndex[importSpec.Imp]; exists && label.Repo != c.RepoName {
-		apparantName := c.ModuleToApparentName(label.Repo)
-		// Empty apparentName means that there is no such a repository added by bazel_dep
-		if apparantName != "" {
-			label.Repo = apparantName
-			return label
-		}
-		if _, exists := lang.notFoundBzlModDeps[label.Repo]; !exists {
-			// Warn only once per missing module_dep
-			lang.notFoundBzlModDeps[label.Repo] = true
-			log.Printf("%v: Resolved mapping of '#include %v' to %v, but 'bazel_dep(name = \"%v\")' is missing in MODULE.bazel", from, importSpec.Imp, label, label.Repo)
+	if conf.useBuiltinBzlmodIndex {
+		if label, exists := lang.bzlmodBuiltInIndex[importSpec.Imp]; exists && label.Repo != c.RepoName {
+			apparantName := c.ModuleToApparentName(label.Repo)
+			// Empty apparentName means that there is no such a repository added by bazel_dep
+			if apparantName != "" {
+				label.Repo = apparantName
+				return label
+			}
+			if _, exists := lang.notFoundBzlModDeps[label.Repo]; !exists {
+				// Warn only once per missing module_dep
+				lang.notFoundBzlModDeps[label.Repo] = true
+				log.Printf("%v: Resolved mapping of '#include %v' to %v, but 'bazel_dep(name = \"%v\")' is missing in MODULE.bazel", from, importSpec.Imp, label, label.Repo)
+			}
 		}
 	}
 


### PR DESCRIPTION
The builtin index created by indexing Bazel Central Registry is useful as simple external dependenices provider, but might be conflicting with more complicated providers, eg. defined using custom index files. We add an option to disable dependency resolution using this method. It's still enabled by default. 

Also fixes dependency resolution to using builtin-index when running on indexed project. Now we discard builtin-index results if they point to the same repository as defined in `config.RepoName` - available since Gazelle 0.45.0, see https://github.com/bazel-contrib/bazel-gazelle/pull/2157