### PR TITLE
Provide VS Code debugging configuration for gazelle_cc binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 bazel-*
-.vscode
 sandbox/*
 .cache
 .scala-build

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,28 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "gazelle_cc in example/bzlmod",
+      "type": "go",
+      "request": "launch",
+      "mode": "exec",
+      "program": "${workspaceFolder}/example/bzlmod/bazel-bin/gazelle_cc_/gazelle_cc",
+      "preLaunchTask": "bazel: build debuggable gazelle_cc in example/bzlmod",
+      "cwd": "${workspaceFolder}/example/bzlmod",
+      "substitutePath": [
+        /*
+          This is necessary due to the way Bazel sandboxes its build outputs. Source paths embedded in the debugging
+          metadata of compiled binaries may not match the actual file paths on disk.
+         */
+        {
+          "from": "${workspaceFolder}",
+          "to": "external/gazelle_cc+"
+        },
+        {
+          "from": "${workspaceFolder}/example/bzlmod/bazel-bzlmod/external/gazelle+",
+          "to": "external/gazelle+"
+        }
+      ]
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,19 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "bazel: build debuggable gazelle_cc in example/bzlmod",
+      "type": "process",
+      "command": "bazel",
+      "args": [
+        "build",
+        "--compilation_mode=dbg",
+        ":gazelle_cc"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}/example/bzlmod",
+      },
+      "group": "build"
+    }
+  ]
+}

--- a/example/bzlmod/README.md
+++ b/example/bzlmod/README.md
@@ -12,3 +12,9 @@ It would create following targets:
 | //proto:example | cc_binary |
 
 These can be built using `bazel build //...`.
+
+# VS Code debugging integration (for contributors)
+
+You can play around here, testing new features, with step-by-step debugging of `gazelle_cc` binary. Activate the **"Run and Debug"** panel on the VS Code sidebar and select the configuration **"gazelle_cc in example/bzlmod"**, prepared especially for this purpose.
+
+See https://code.visualstudio.com/docs/debugtest/debugging for more details about debugging in VS Code.


### PR DESCRIPTION
`:gazelle_cc` binary inside `example/bzlmod` directory can now be debugged with the integrated VS Code GUI debugger.

Source paths in the debugging metadata had to be adjusted so that VS Code could correctly map the currently evaluated instruction to the actual place in the source code.