### PR TITLE
Improve license_check.sh

### DIFF
--- a/index/internal/bazel/proto/build.proto
+++ b/index/internal/bazel/proto/build.proto
@@ -1,17 +1,17 @@
-// Copyright 2025 EngFlow Inc. All rights reserved.
+// Copyright 2014 The Bazel Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//    http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
+//
 // This file contains the protocol buffer representation of a build
 // file or 'blaze query --output=proto' call.
 

--- a/scripts/license_check.sh
+++ b/scripts/license_check.sh
@@ -5,6 +5,7 @@ shopt -s extglob
 # Paths ignored when checking the headers
 IGNORE_PATHS=(
   "example/*"
+  "index/internal/bazel/proto/build.proto"
   "language/cc/testdata/*"
 )
 


### PR DESCRIPTION
- Include `*.proto` files in the license checking.
- Allow replacement of incorrect copyright headers instead of only appending the new ones.