### PR TITLE
Warn about ambiguous imported rules

### DIFF
--- a/internal/collections/set.go
+++ b/internal/collections/set.go
@@ -136,7 +136,7 @@ func (s Set[T]) Intersects(other Set[T]) bool {
 }
 
 // Values returns a slice containing all elements in the Set.
-// The order is not guaranteed.
+// The order is not guaranteed. For guaranteed order, use SortedValues.
 //
 // Example:
 //
@@ -144,4 +144,14 @@ func (s Set[T]) Intersects(other Set[T]) bool {
 //	vals := s.Values() => []string{"a", "b"} (order may vary)
 func (s Set[T]) Values() []T {
 	return slices.Collect(maps.Keys(s))
+}
+
+// SortedValues returns a sorted slice containing all elements in the Set.
+//
+// Example:
+//
+//	s := SetOf("a", "b")
+//	vals := s.SortedValues(strings.Compare) => []string{"a", "b"} (order guaranteed)
+func (s Set[T]) SortedValues(cmp func(l, r T) int) []T {
+	return slices.SortedFunc(maps.Keys(s), cmp)
 }

--- a/internal/collections/set_test.go
+++ b/internal/collections/set_test.go
@@ -15,6 +15,7 @@
 package collections
 
 import (
+	"cmp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -330,6 +331,37 @@ func TestSet_Values(t *testing.T) {
 			result := tt.set.Values()
 			// Sort the result since the order is not guaranteed
 			assert.ElementsMatch(t, tt.expected, result)
+		})
+	}
+}
+
+func TestSet_SortedValues(t *testing.T) {
+	tests := []struct {
+		name     string
+		set      Set[int]
+		expected []int
+	}{
+		{
+			name:     "empty set",
+			set:      SetOf[int](),
+			expected: nil,
+		},
+		{
+			name:     "single element",
+			set:      SetOf(1),
+			expected: []int{1},
+		},
+		{
+			name:     "multiple elements",
+			set:      SetOf(1, 2, 3),
+			expected: []int{1, 2, 3},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.set.SortedValues(cmp.Compare)
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }

--- a/language/cc/generate.go
+++ b/language/cc/generate.go
@@ -69,6 +69,8 @@ func extractImports(args language.GenerateArgs, files []sourceFile, sourceInfos 
 		sourceInfo := sourceInfos[file]
 		for _, include := range sourceInfo.CollectIncludes() {
 			*includes = append(*includes, ccInclude{
+				sourceFile:      file,
+				lineNumber:      include.LineNumber,
 				path:            path.Clean(include.Path),
 				fromDirectory:   args.Rel,
 				isSystemInclude: include.IsSystem,

--- a/language/cc/lang.go
+++ b/language/cc/lang.go
@@ -41,6 +41,10 @@ type (
 		notFoundBzlModDeps map[string]bool
 	}
 	ccInclude struct {
+		// File where this include was found
+		sourceFile sourceFile
+		// Line number in sourceFile where this include was found
+		lineNumber int
 		// Include path extracted from brackets or double quotes
 		path string
 		// Directory from which include is resolved

--- a/language/cc/resolve.go
+++ b/language/cc/resolve.go
@@ -182,9 +182,7 @@ func (lang *ccLanguage) Resolve(c *config.Config, ix *resolve.RuleIndex, rc *rep
 			}
 		}
 		if len(deps) > 0 {
-			r.SetAttr(attributeName, slices.SortedStableFunc(maps.Keys(deps), func(l, r label.Label) int {
-				return strings.Compare(l.String(), r.String())
-			}))
+			r.SetAttr(attributeName, labelsSetToSlice(deps))
 		}
 		return deps
 	}
@@ -214,11 +212,15 @@ func extractLabelsFromFindResults(results []resolve.FindResult) collections.Set[
 	return labels
 }
 
+func labelsSetToSlice(labels collections.Set[label.Label]) []label.Label {
+	return slices.SortedFunc(maps.Keys(labels), func(l, r label.Label) int {
+		return strings.Compare(l.String(), r.String())
+	})
+}
+
 func labelsToString(labels collections.Set[label.Label]) string {
 	labelStrings := make([]string, 0, len(labels))
-	for _, l := range slices.SortedFunc(maps.Keys(labels), func(l, r label.Label) int {
-		return strings.Compare(l.String(), r.String())
-	}) {
+	for _, l := range labelsSetToSlice(labels) {
 		labelStrings = append(labelStrings, l.String())
 	}
 	return fmt.Sprintf("[%s]", strings.Join(labelStrings, ", "))

--- a/language/cc/resolve.go
+++ b/language/cc/resolve.go
@@ -216,7 +216,9 @@ func extractLabelsFromFindResults(results []resolve.FindResult) collections.Set[
 
 func labelsToString(labels collections.Set[label.Label]) string {
 	labelStrings := make([]string, 0, len(labels))
-	for l := range labels {
+	for _, l := range slices.SortedFunc(maps.Keys(labels), func(l, r label.Label) int {
+		return strings.Compare(l.String(), r.String())
+	}) {
 		labelStrings = append(labelStrings, l.String())
 	}
 	return fmt.Sprintf("[%s]", strings.Join(labelStrings, ", "))

--- a/language/cc/testdata/ambiguous_import/MODULE.bazel
+++ b/language/cc/testdata/ambiguous_import/MODULE.bazel
@@ -1,0 +1,6 @@
+module(
+    name = "test",
+    version = "0.1.0",
+)
+
+bazel_dep(name = "rules_cc", version = "0.1.0")

--- a/language/cc/testdata/ambiguous_import/MODULE.bazel
+++ b/language/cc/testdata/ambiguous_import/MODULE.bazel
@@ -1,6 +1,0 @@
-module(
-    name = "test",
-    version = "0.1.0",
-)
-
-bazel_dep(name = "rules_cc", version = "0.1.0")

--- a/language/cc/testdata/ambiguous_import/ambiguous/BUILD.in
+++ b/language/cc/testdata/ambiguous_import/ambiguous/BUILD.in
@@ -1,0 +1,13 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "rule1",
+    hdrs = ["header.h"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "rule2",
+    hdrs = ["header.h"],
+    visibility = ["//visibility:public"],
+)

--- a/language/cc/testdata/ambiguous_import/ambiguous/BUILD.out
+++ b/language/cc/testdata/ambiguous_import/ambiguous/BUILD.out
@@ -1,0 +1,13 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "rule1",
+    hdrs = ["header.h"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "rule2",
+    hdrs = ["header.h"],
+    visibility = ["//visibility:public"],
+)

--- a/language/cc/testdata/ambiguous_import/ambiguous/header.h
+++ b/language/cc/testdata/ambiguous_import/ambiguous/header.h
@@ -1,0 +1,2 @@
+#pragma once
+#define GREETING "Hello, World!"

--- a/language/cc/testdata/ambiguous_import/expectedStderr.txt
+++ b/language/cc/testdata/ambiguous_import/expectedStderr.txt
@@ -1,0 +1,1 @@
+gazelle: @test//mylib: multiple rules found for #include "ambiguous/header.h" at mylib/mylib.cc:2, using @test//ambiguous:rule1

--- a/language/cc/testdata/ambiguous_import/expectedStderr.txt
+++ b/language/cc/testdata/ambiguous_import/expectedStderr.txt
@@ -1,1 +1,1 @@
-gazelle: @test//mylib: multiple rules found for #include "ambiguous/header.h" at mylib/mylib.cc:2: [@test//ambiguous:rule1, @test//ambiguous:rule2]; using @test//ambiguous:rule1
+gazelle: //mylib: found ambiguous rules providing '#include "ambiguous/header.h"' at mylib/mylib.cc:2: [//ambiguous:rule1 //ambiguous:rule2]; using //ambiguous:rule1

--- a/language/cc/testdata/ambiguous_import/expectedStderr.txt
+++ b/language/cc/testdata/ambiguous_import/expectedStderr.txt
@@ -1,1 +1,1 @@
-gazelle: @test//mylib: multiple rules found for #include "ambiguous/header.h" at mylib/mylib.cc:2, using @test//ambiguous:rule1
+gazelle: @test//mylib: multiple rules found for #include "ambiguous/header.h" at mylib/mylib.cc:2: [@test//ambiguous:rule1, @test//ambiguous:rule2]; using @test//ambiguous:rule1

--- a/language/cc/testdata/ambiguous_import/mylib/BUILD.out
+++ b/language/cc/testdata/ambiguous_import/mylib/BUILD.out
@@ -1,0 +1,9 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "mylib",
+    srcs = ["mylib.cc"],
+    hdrs = ["mylib.h"],
+    implementation_deps = ["//ambiguous:rule1"],
+    visibility = ["//visibility:public"],
+)

--- a/language/cc/testdata/ambiguous_import/mylib/mylib.cc
+++ b/language/cc/testdata/ambiguous_import/mylib/mylib.cc
@@ -1,0 +1,10 @@
+#include "mylib/mylib.h"
+#include "ambiguous/header.h"
+
+namespace mylib {
+
+std::string greet() {
+    return GREETING;
+}
+
+}

--- a/language/cc/testdata/ambiguous_import/mylib/mylib.h
+++ b/language/cc/testdata/ambiguous_import/mylib/mylib.h
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace mylib {
+
+std::string greet();
+
+}

--- a/language/internal/cc/parser/directive.go
+++ b/language/internal/cc/parser/directive.go
@@ -28,9 +28,9 @@ type (
 	// IncludeDirective represents a `#include` or `#include_next` preprocessor directive.
 	// If IsSystem is true, angle brackets were used (<...>), otherwise quotes ("...").
 	IncludeDirective struct {
-		Path     string // Path of the included file
-		IsSystem bool   // True if system include (angle brackets), false if user include (quotes)
-
+		Path       string // Path of the included file
+		IsSystem   bool   // True if system include (angle brackets), false if user include (quotes)
+		LineNumber int    // Line number where this directive was found
 	}
 	// DefineDirective represents a `#define` preprocessor directive, including
 	// the macro name and any replacement tokens.

--- a/language/internal/cc/parser/parser.go
+++ b/language/internal/cc/parser/parser.go
@@ -229,7 +229,7 @@ func (p *parser) parseIncludeDirective(_ string) (Directive, error) {
 		if err != nil {
 			return nil, fmt.Errorf("missing closing bracket: %v", err)
 		}
-		return IncludeDirective{Path: path, IsSystem: true}, nil
+		return IncludeDirective{Path: path, IsSystem: true, LineNumber: p.tr.lineNumber}, nil
 	default:
 		path := token
 		if !strings.HasPrefix(path, "\"") || !strings.HasSuffix(path, "\"") {
@@ -239,7 +239,7 @@ func (p *parser) parseIncludeDirective(_ string) (Directive, error) {
 		if strings.Contains(unquoted, "\"") {
 			return nil, errors.New("malformed include, quotes inside path")
 		}
-		return IncludeDirective{Path: unquoted, IsSystem: false}, nil
+		return IncludeDirective{Path: unquoted, IsSystem: false, LineNumber: p.tr.lineNumber}, nil
 	}
 }
 

--- a/language/internal/cc/parser/parser_test.go
+++ b/language/internal/cc/parser/parser_test.go
@@ -33,9 +33,9 @@ func TestParseIncludes(t *testing.T) {
 # include <math.h>
 `,
 			expected: []Directive{
-				IncludeDirective{Path: "stdio.h", IsSystem: true},
-				IncludeDirective{Path: "myheader.h"},
-				IncludeDirective{Path: "math.h", IsSystem: true},
+				IncludeDirective{Path: "stdio.h", IsSystem: true, LineNumber: 2},
+				IncludeDirective{Path: "myheader.h", LineNumber: 3},
+				IncludeDirective{Path: "math.h", IsSystem: true, LineNumber: 4},
 			},
 		},
 		{
@@ -52,8 +52,8 @@ func TestParseIncludes(t *testing.T) {
 # unknown_directive
 `,
 			expected: []Directive{
-				IncludeDirective{Path: "valid.h"},
-				IncludeDirective{Path: "other_valid", IsSystem: true},
+				IncludeDirective{Path: "valid.h", LineNumber: 2},
+				IncludeDirective{Path: "other_valid", IsSystem: true, LineNumber: 8},
 			},
 		},
 	}
@@ -90,32 +90,32 @@ func TestParseConditionalIncludes(t *testing.T) {
 `,
 			expected: SourceInfo{
 				Directives: []Directive{
-					IncludeDirective{Path: "common.h"},
+					IncludeDirective{Path: "common.h", LineNumber: 2},
 					IfBlock{Branches: []ConditionalBranch{
 						{
 							Kind:      IfBranch,
 							Condition: Defined{Ident("_WIN32")},
 							Body: []Directive{
-								IncludeDirective{Path: "windows.h", IsSystem: true},
+								IncludeDirective{Path: "windows.h", IsSystem: true, LineNumber: 4},
 							},
 						}, {
 							Kind:      ElifBranch,
 							Condition: Defined{Ident("__APPLE__")},
-							Body:      []Directive{IncludeDirective{Path: "unistd.h", IsSystem: true}},
+							Body:      []Directive{IncludeDirective{Path: "unistd.h", IsSystem: true, LineNumber: 7}},
 						}, {
 							Kind:      ElifBranch,
 							Condition: Not{Defined{Ident("__linux__")}},
 							Body: []Directive{
-								IncludeDirective{Path: "fcntl.h", IsSystem: true},
+								IncludeDirective{Path: "fcntl.h", IsSystem: true, LineNumber: 9},
 							},
 						}, {
 							Kind: ElseBranch,
 							Body: []Directive{
-								IncludeDirective{Path: "other.h"},
+								IncludeDirective{Path: "other.h", LineNumber: 11},
 							},
 						},
 					}},
-					IncludeDirective{Path: "last.h"},
+					IncludeDirective{Path: "last.h", LineNumber: 13},
 				},
 			},
 		},
@@ -141,22 +141,22 @@ func TestParseConditionalIncludes(t *testing.T) {
 							Kind:      IfBranch,
 							Condition: Defined{Ident("_WIN32")},
 							Body: []Directive{
-								IncludeDirective{Path: "windows.h"},
+								IncludeDirective{Path: "windows.h", LineNumber: 3},
 							},
 						}, {
 							Kind:      ElifBranch,
 							Condition: Defined{Ident("__APPLE__")},
-							Body:      []Directive{IncludeDirective{Path: "unistd.h"}},
+							Body:      []Directive{IncludeDirective{Path: "unistd.h", LineNumber: 5}},
 						}, {
 							Kind:      ElifBranch,
 							Condition: Not{Defined{Ident("__linux__")}},
 							Body: []Directive{
-								IncludeDirective{Path: "fcntl.h"},
+								IncludeDirective{Path: "fcntl.h", LineNumber: 9},
 							},
 						}, {
 							Kind: ElseBranch,
 							Body: []Directive{
-								IncludeDirective{Path: "other.h"},
+								IncludeDirective{Path: "other.h", LineNumber: 11},
 							},
 						},
 					}},
@@ -185,14 +185,14 @@ func TestParseConditionalIncludes(t *testing.T) {
 								Defined{Ident("__ANDROID__")},
 							},
 							Body: []Directive{
-								IncludeDirective{Path: "ui.h"},
+								IncludeDirective{Path: "ui.h", LineNumber: 3},
 							},
 						},
 						{
 							Kind:      ElifBranch,
 							Condition: Defined{Ident("_WIN32")},
 							Body: []Directive{
-								IncludeDirective{Path: "cli.h"},
+								IncludeDirective{Path: "cli.h", LineNumber: 5},
 							},
 						},
 					}},
@@ -226,13 +226,13 @@ func TestParseConditionalIncludes(t *testing.T) {
 								},
 							},
 							Body: []Directive{
-								IncludeDirective{Path: "feature.h"},
+								IncludeDirective{Path: "feature.h", LineNumber: 5},
 							},
 						},
 						{
 							Kind: ElseBranch,
 							Body: []Directive{
-								IncludeDirective{Path: "nofeature.h"},
+								IncludeDirective{Path: "nofeature.h", LineNumber: 7},
 							},
 						},
 					}},
@@ -257,20 +257,20 @@ func TestParseConditionalIncludes(t *testing.T) {
 							Kind:      IfBranch,
 							Condition: Ident("TARGET_IOS"),
 							Body: []Directive{
-								IncludeDirective{Path: "ios_api.h"},
+								IncludeDirective{Path: "ios_api.h", LineNumber: 3},
 							},
 						},
 						{
 							Kind:      ElifBranch,
 							Condition: Not{Ident("TARGET_WINDOWS")},
 							Body: []Directive{
-								IncludeDirective{Path: "unix_api.h"},
+								IncludeDirective{Path: "unix_api.h", LineNumber: 5},
 							},
 						},
 						{
 							Kind: ElseBranch,
 							Body: []Directive{
-								IncludeDirective{Path: "windows_api.h"},
+								IncludeDirective{Path: "windows_api.h", LineNumber: 7},
 							},
 						},
 					}},
@@ -293,13 +293,13 @@ func TestParseConditionalIncludes(t *testing.T) {
 							Kind:      IfBranch,
 							Condition: Compare{Left: Ident("__WINT_WIDTH__"), Op: ">=", Right: ConstantInt(32)},
 							Body: []Directive{
-								IncludeDirective{Path: "wideint.h"},
+								IncludeDirective{Path: "wideint.h", LineNumber: 3},
 							},
 						},
 						{
 							Kind: ElseBranch,
 							Body: []Directive{
-								IncludeDirective{Path: "narrowint.h"},
+								IncludeDirective{Path: "narrowint.h", LineNumber: 5},
 							},
 						},
 					}},
@@ -324,21 +324,21 @@ func TestParseConditionalIncludes(t *testing.T) {
 							Kind:      IfBranch,
 							Condition: Compare{Left: ConstantInt(1), Op: "==", Right: Ident("__LITTLE_ENDIAN__")},
 							Body: []Directive{
-								IncludeDirective{Path: "a.h"},
+								IncludeDirective{Path: "a.h", LineNumber: 3},
 							},
 						},
 						{
 							Kind:      ElifBranch,
 							Condition: Compare{ConstantInt(0), "!=", Ident("TARGET_IOS")},
 							Body: []Directive{
-								IncludeDirective{Path: "b.h"},
+								IncludeDirective{Path: "b.h", LineNumber: 5},
 							},
 						},
 						{
 							Kind:      ElifBranch,
 							Condition: Compare{Left: ConstantInt(32), Op: ">", Right: Ident("POINTER_SIZE")},
 							Body: []Directive{
-								IncludeDirective{Path: "c.h"},
+								IncludeDirective{Path: "c.h", LineNumber: 7},
 							},
 						},
 					}},
@@ -363,20 +363,20 @@ func TestParseConditionalIncludes(t *testing.T) {
 							Kind:      IfBranch,
 							Condition: Compare{Left: Ident("__ARM_ARCH"), Op: "==", Right: ConstantInt(8)},
 							Body: []Directive{
-								IncludeDirective{Path: "armv8.h"},
+								IncludeDirective{Path: "armv8.h", LineNumber: 3},
 							},
 						},
 						{
 							Kind:      ElifBranch,
 							Condition: Compare{Left: Ident("__ARM_ARCH"), Op: ">", Right: ConstantInt(8)},
 							Body: []Directive{
-								IncludeDirective{Path: "armv9.h"},
+								IncludeDirective{Path: "armv9.h", LineNumber: 5},
 							},
 						},
 						{
 							Kind: ElseBranch,
 							Body: []Directive{
-								IncludeDirective{Path: "armlegacy.h"},
+								IncludeDirective{Path: "armlegacy.h", LineNumber: 7},
 							},
 						},
 					}},
@@ -411,36 +411,36 @@ func TestParseConditionalIncludes(t *testing.T) {
 							Kind:      IfBranch,
 							Condition: Defined{Ident("FOO")},
 							Body: []Directive{
-								IncludeDirective{Path: "foo.h"},
+								IncludeDirective{Path: "foo.h", LineNumber: 3},
 								IfBlock{Branches: []ConditionalBranch{
 									{
 										Kind:      IfBranch,
 										Condition: Defined{Ident("BAR")},
 										Body: []Directive{
-											IncludeDirective{Path: "bar.h"},
+											IncludeDirective{Path: "bar.h", LineNumber: 5},
 											IfBlock{Branches: []ConditionalBranch{
 												{
 													Kind:      IfBranch,
 													Condition: Defined{Ident("BAZ")},
-													Body:      []Directive{IncludeDirective{Path: "baz.h"}},
+													Body:      []Directive{IncludeDirective{Path: "baz.h", LineNumber: 7}},
 												},
 												{
 													Kind:      ElifBranch,
 													Condition: Defined{Ident("QUX")},
-													Body:      []Directive{IncludeDirective{Path: "qux.h"}},
+													Body:      []Directive{IncludeDirective{Path: "qux.h", LineNumber: 9}},
 												},
 												{
 													Kind: ElseBranch,
-													Body: []Directive{IncludeDirective{Path: "nobaz.h"}},
+													Body: []Directive{IncludeDirective{Path: "nobaz.h", LineNumber: 11}},
 												},
 											}},
 										}}, {
 										Kind: ElseBranch,
-										Body: []Directive{IncludeDirective{Path: "nobar.h"}},
+										Body: []Directive{IncludeDirective{Path: "nobar.h", LineNumber: 14}},
 									}}}}},
 						{
 							Kind: ElseBranch,
-							Body: []Directive{IncludeDirective{Path: "nofoo.h"}},
+							Body: []Directive{IncludeDirective{Path: "nofoo.h", LineNumber: 17}},
 						},
 					},
 					},
@@ -458,7 +458,7 @@ func TestParseConditionalIncludes(t *testing.T) {
 						{
 							Kind:      IfBranch,
 							Condition: Compare{Left: Not{Ident("A")}, Op: "==", Right: Ident("B")},
-							Body:      []Directive{IncludeDirective{Path: "unistd.h", IsSystem: true}},
+							Body:      []Directive{IncludeDirective{Path: "unistd.h", IsSystem: true, LineNumber: 3}},
 						},
 					}},
 				},
@@ -479,7 +479,7 @@ func TestParseConditionalIncludes(t *testing.T) {
 							Condition: Not{Defined{Ident("FOO_H")}},
 							Body: []Directive{
 								DefineDirective{Name: "FOO_H", Args: []string{}, Body: []string{}},
-								IncludeDirective{Path: "bar.h"},
+								IncludeDirective{Path: "bar.h", LineNumber: 4},
 								UndefineDirective{Name: "FOO_H"},
 							},
 						},
@@ -534,13 +534,13 @@ func TestParseConditionalIncludes(t *testing.T) {
 							Kind:      IfBranch,
 							Condition: Apply{Name: Ident("IS_EQUAL"), Args: []Expr{Ident("FOO"), Ident("BAR")}},
 							Body: []Directive{
-								IncludeDirective{Path: "foo.h"},
+								IncludeDirective{Path: "foo.h", LineNumber: 4},
 							},
 						},
 						{
 							Kind: ElseBranch,
 							Body: []Directive{
-								IncludeDirective{Path: "bar.h"},
+								IncludeDirective{Path: "bar.h", LineNumber: 6},
 							},
 						},
 					},

--- a/language/internal/cc/parser/source_info_test.go
+++ b/language/internal/cc/parser/source_info_test.go
@@ -40,18 +40,18 @@ func TestCollectIncludesAndCollectReachableIncludes(t *testing.T) {
 				#include <bar.h>
 			`,
 			wantAll: []IncludeDirective{
-				{Path: "stdio.h", IsSystem: true},
-				{Path: "foo.h"},
-				{Path: "bar.h", IsSystem: true},
+				{Path: "stdio.h", IsSystem: true, LineNumber: 2},
+				{Path: "foo.h", LineNumber: 3},
+				{Path: "bar.h", IsSystem: true, LineNumber: 4},
 			},
 			reachCases: []macrosCase{
 				{
 					name: "no macros",
 					env:  Environment{},
 					want: []IncludeDirective{
-						{Path: "stdio.h", IsSystem: true},
-						{Path: "foo.h"},
-						{Path: "bar.h", IsSystem: true},
+						{Path: "stdio.h", IsSystem: true, LineNumber: 2},
+						{Path: "foo.h", LineNumber: 3},
+						{Path: "bar.h", IsSystem: true, LineNumber: 4},
 					},
 				},
 			},
@@ -65,21 +65,21 @@ func TestCollectIncludesAndCollectReachableIncludes(t *testing.T) {
 				#include "always.h"
 			`,
 			wantAll: []IncludeDirective{
-				{Path: "foo.h"},
-				{Path: "always.h"},
+				{Path: "foo.h", LineNumber: 3},
+				{Path: "always.h", LineNumber: 5},
 			},
 			reachCases: []macrosCase{
 				{
 					name: "FOO undefined",
 					env:  Environment{},
-					want: []IncludeDirective{{Path: "always.h"}},
+					want: []IncludeDirective{{Path: "always.h", LineNumber: 5}},
 				},
 				{
 					name: "FOO defined",
 					env:  Environment{"FOO": 1},
 					want: []IncludeDirective{
-						{Path: "foo.h"},
-						{Path: "always.h"},
+						{Path: "foo.h", LineNumber: 3},
+						{Path: "always.h", LineNumber: 5},
 					},
 				},
 			},
@@ -96,25 +96,25 @@ func TestCollectIncludesAndCollectReachableIncludes(t *testing.T) {
 				#endif
 			`,
 			wantAll: []IncludeDirective{
-				{Path: "a.h"},
-				{Path: "b.h"},
-				{Path: "c.h"},
+				{Path: "a.h", LineNumber: 3},
+				{Path: "b.h", LineNumber: 5},
+				{Path: "c.h", LineNumber: 7},
 			},
 			reachCases: []macrosCase{
 				{
 					name: "A defined",
 					env:  Environment{"A": 1},
-					want: []IncludeDirective{{Path: "a.h"}},
+					want: []IncludeDirective{{Path: "a.h", LineNumber: 3}},
 				},
 				{
 					name: "B defined",
 					env:  Environment{"B": 1},
-					want: []IncludeDirective{{Path: "b.h"}},
+					want: []IncludeDirective{{Path: "b.h", LineNumber: 5}},
 				},
 				{
 					name: "none defined",
 					env:  Environment{},
-					want: []IncludeDirective{{Path: "c.h"}},
+					want: []IncludeDirective{{Path: "c.h", LineNumber: 7}},
 				},
 			},
 		},
@@ -131,14 +131,14 @@ func TestCollectIncludesAndCollectReachableIncludes(t *testing.T) {
 				#endif
 			`,
 			wantAll: []IncludeDirective{
-				{Path: "foo.h"},
-				{Path: "should_not_appear.h"},
+				{Path: "foo.h", LineNumber: 4},
+				{Path: "should_not_appear.h", LineNumber: 8},
 			},
 			reachCases: []macrosCase{
 				{
 					name: "no macros",
 					env:  Environment{},
-					want: []IncludeDirective{{Path: "foo.h"}},
+					want: []IncludeDirective{{Path: "foo.h", LineNumber: 4}},
 				},
 			},
 		},
@@ -154,31 +154,31 @@ func TestCollectIncludesAndCollectReachableIncludes(t *testing.T) {
 				#include "always.h"
 			`,
 			wantAll: []IncludeDirective{
-				{Path: "outer.h"},
-				{Path: "inner.h"},
-				{Path: "always.h"},
+				{Path: "outer.h", LineNumber: 3},
+				{Path: "inner.h", LineNumber: 5},
+				{Path: "always.h", LineNumber: 8},
 			},
 			reachCases: []macrosCase{
 				{
 					name: "none defined",
 					env:  Environment{},
-					want: []IncludeDirective{{Path: "always.h"}},
+					want: []IncludeDirective{{Path: "always.h", LineNumber: 8}},
 				},
 				{
 					name: "OUTER only",
 					env:  Environment{"OUTER": 1},
 					want: []IncludeDirective{
-						{Path: "outer.h"},
-						{Path: "always.h"},
+						{Path: "outer.h", LineNumber: 3},
+						{Path: "always.h", LineNumber: 8},
 					},
 				},
 				{
 					name: "OUTER and INNER",
 					env:  Environment{"OUTER": 1, "INNER": 1},
 					want: []IncludeDirective{
-						{Path: "outer.h"},
-						{Path: "inner.h"},
-						{Path: "always.h"},
+						{Path: "outer.h", LineNumber: 3},
+						{Path: "inner.h", LineNumber: 5},
+						{Path: "always.h", LineNumber: 8},
 					},
 				},
 			},
@@ -194,14 +194,14 @@ func TestCollectIncludesAndCollectReachableIncludes(t *testing.T) {
 				#endif
 			`,
 			wantAll: []IncludeDirective{
-				{Path: "two.h"},
-				{Path: "three.h"},
+				{Path: "two.h", LineNumber: 4},
+				{Path: "three.h", LineNumber: 6},
 			},
 			reachCases: []macrosCase{
 				{
 					name: "no macros",
 					env:  Environment{},
-					want: []IncludeDirective{{Path: "two.h"}},
+					want: []IncludeDirective{{Path: "two.h", LineNumber: 4}},
 				},
 			},
 		},
@@ -215,7 +215,7 @@ func TestCollectIncludesAndCollectReachableIncludes(t *testing.T) {
 				#endif
 			`,
 			wantAll: []IncludeDirective{
-				{Path: "foo.h"},
+				{Path: "foo.h", LineNumber: 5},
 			},
 			reachCases: []macrosCase{
 				{


### PR DESCRIPTION
In some cases, one `importSpec` may point to more than one rule. It occurs when a single header file belongs to more than one rule. Gazelle will arbitrarily choose the first matching rule; however, the user should be aware of the situation.