### PR TITLE
Fix cc_search test

### DIFF
--- a/language/cc/testdata/cc_search/BUILD.in
+++ b/language/cc/testdata/cc_search/BUILD.in
@@ -1,4 +1,4 @@
 # gazelle:cc_search "" stripped_prefix_abs
 # gazelle:cc_search "" stripped_prefix_rel
 # gazelle:cc_search extra ""
-# gazelle:cc_search extra/stripped_include_prefix_and_prefix/inc stripped_include_prefix_and_prefix
+# gazelle:cc_search extra/stripped_prefix_and_prefix/inc stripped_prefix_and_prefix

--- a/language/cc/testdata/cc_search/BUILD.out
+++ b/language/cc/testdata/cc_search/BUILD.out
@@ -1,4 +1,4 @@
 # gazelle:cc_search "" stripped_prefix_abs
 # gazelle:cc_search "" stripped_prefix_rel
 # gazelle:cc_search extra ""
-# gazelle:cc_search extra/stripped_include_prefix_and_prefix/inc stripped_include_prefix_and_prefix
+# gazelle:cc_search extra/stripped_prefix_and_prefix/inc stripped_prefix_and_prefix

--- a/language/cc/testdata/cc_search/stripped_prefix_and_prefix/inc/stripped_include_prefix_and_prefix.h
+++ b/language/cc/testdata/cc_search/stripped_prefix_and_prefix/inc/stripped_include_prefix_and_prefix.h
@@ -1,3 +1,0 @@
-#pragma once
-
-inline void stripped_include_prefix_and_prefix() {}

--- a/language/cc/testdata/cc_search/stripped_prefix_and_prefix/inc/stripped_prefix_and_prefix.h
+++ b/language/cc/testdata/cc_search/stripped_prefix_and_prefix/inc/stripped_prefix_and_prefix.h
@@ -1,0 +1,3 @@
+#pragma once
+
+inline void stripped_prefix_and_prefix() {}

--- a/language/cc/testdata/cc_search/use/BUILD.out
+++ b/language/cc/testdata/cc_search/use/BUILD.out
@@ -7,6 +7,7 @@ cc_library(
         "//prefix",
         "//self",
         "//stripped_prefix_abs",
+        "//stripped_prefix_and_prefix",
         "//stripped_prefix_rel",
     ],
     visibility = ["//visibility:public"],

--- a/language/cc/testdata/cc_search/use/use.cc
+++ b/language/cc/testdata/cc_search/use/use.cc
@@ -2,7 +2,7 @@
 #include "self/self.h"
 #include "stripped_prefix_abs.h"
 #include "stripped_prefix_rel.h"
-#include "extra/stripped_include_prefix_and_prefix.h"
+#include "extra/stripped_prefix_and_prefix.h"
 
 void use() {
 	prefix();


### PR DESCRIPTION
Header `stripped_include_prefix_and_prefix.h` could not be found because the library rule in `language/cc/testdata/cc_search/stripped_prefix_and_prefix/BUILD.in` referred to it as `"inc/stripped_prefix_and_prefix.h"`.

So I've renamed `stripped_include_prefix_and_prefix.h` ➡️ `stripped_prefix_and_prefix.h` to make it consistent.