### PR TITLE
Add Deepwiki badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/EngFlow/gazelle_cc)
+
 # Gazelle C++ Extension
 
 This repository contains a [Gazelle](https://github.com/bazel-contrib/bazel-gazelle) extension for C++ projects.


### PR DESCRIPTION
When a badge is added to the repo's README file, DeepWiki will auto-refresh documentation weekly.