### PR TITLE
Allow using windows-specific main function names like WinMain

### DIFF
--- a/language/internal/cc/parser/parser.go
+++ b/language/internal/cc/parser/parser.go
@@ -523,8 +523,17 @@ func (p *parser) parseDirective() (Directive, error) {
 	}
 }
 
+func isMainFunctionIdentifier(ident string) bool {
+	switch ident {
+	case "main", "wmain", "_tmain", "WinMain", "wWinMain", "_tWinMain":
+		return true
+	default:
+		return false
+	}
+}
+
 func (p *parser) tryParseMainFunction() bool {
-	if len(p.tokensLeft) >= 3 && p.tokensLeft[0].Content == "int" && p.tokensLeft[1].Content == "main" && p.tokensLeft[2].Content == "(" {
+	if len(p.tokensLeft) >= 3 && p.tokensLeft[0].Content == "int" && isMainFunctionIdentifier(p.tokensLeft[1].Content) && p.tokensLeft[2].Content == "(" {
 		p.dropTokens(3)
 		return true
 	}

--- a/language/internal/cc/parser/parser_test.go
+++ b/language/internal/cc/parser/parser_test.go
@@ -730,6 +730,10 @@ func TestParseSourceHasMain(t *testing.T) {
 			expected: true,
 			input:    `/* that our main */ int main(int argCount, char** values){return 0;}`,
 		},
+		{
+			expected: true,
+			input:    "int wmain( int argc, wchar_t *argv[ ], wchar_t *envp[ ] ) {return 0;}",
+		},
 	}
 
 	for idx, tc := range testCases {


### PR DESCRIPTION
Part of #127 

This is a trivial solution. For multi-platform code, the effective identifier may be hidden under a macro, like:
```cpp
#ifdef _WIN32
#define MAIN wmain
#else
#define MAIN main
#endif

int MAIN() {}
```

So the code above won't work as expected.