### PR TITLE
Handle raw string literals

### DIFF
--- a/language/internal/cc/lexer/lexer_test.go
+++ b/language/internal/cc/lexer/lexer_test.go
@@ -89,47 +89,47 @@ func TestNextToken(t *testing.T) {
 		},
 		{
 			input:    []byte(`L"wide string literal"`),
-			expected: Token{Type: TokenType_LiteralString, Location: CursorInit, Content: `L"wide string literal"`},
+			expected: Token{Type: TokenType_Unassigned, Location: CursorInit, Content: `L"wide string literal"`},
 		},
 		{
 			input:    []byte(`u8"utf-8 string literal"`),
-			expected: Token{Type: TokenType_LiteralString, Location: CursorInit, Content: `u8"utf-8 string literal"`},
+			expected: Token{Type: TokenType_Unassigned, Location: CursorInit, Content: `u8"utf-8 string literal"`},
 		},
 		{
 			input:    []byte(`u"utf-16 string literal"`),
-			expected: Token{Type: TokenType_LiteralString, Location: CursorInit, Content: `u"utf-16 string literal"`},
+			expected: Token{Type: TokenType_Unassigned, Location: CursorInit, Content: `u"utf-16 string literal"`},
 		},
 		{
 			input:    []byte(`U"utf-32 string literal"`),
-			expected: Token{Type: TokenType_LiteralString, Location: CursorInit, Content: `U"utf-32 string literal"`},
+			expected: Token{Type: TokenType_Unassigned, Location: CursorInit, Content: `U"utf-32 string literal"`},
 		},
 		{
 			input:    []byte(`R"(abc)" fake-end)"`),
-			expected: Token{Type: TokenType_LiteralRawString, Location: CursorInit, Content: `R"(abc)"`},
+			expected: Token{Type: TokenType_Unassigned, Location: CursorInit, Content: `R"(abc)"`},
 		},
 		{
 			input:    []byte(`R"delim(abc)delim" fake-end)"`),
-			expected: Token{Type: TokenType_LiteralRawString, Location: CursorInit, Content: `R"delim(abc)delim"`},
+			expected: Token{Type: TokenType_Unassigned, Location: CursorInit, Content: `R"delim(abc)delim"`},
 		},
 		{
 			input:    []byte(`R"delim(abc fake-end)" )delim"`),
-			expected: Token{Type: TokenType_LiteralRawString, Location: CursorInit, Content: `R"delim(abc fake-end)" )delim"`},
+			expected: Token{Type: TokenType_Unassigned, Location: CursorInit, Content: `R"delim(abc fake-end)" )delim"`},
 		},
 		{
 			input:    []byte(`LR"(wide raw string literal)"`),
-			expected: Token{Type: TokenType_LiteralRawString, Location: CursorInit, Content: `LR"(wide raw string literal)"`},
+			expected: Token{Type: TokenType_Unassigned, Location: CursorInit, Content: `LR"(wide raw string literal)"`},
 		},
 		{
 			input:    []byte(`u8R"(utf-8 raw string literal)"`),
-			expected: Token{Type: TokenType_LiteralRawString, Location: CursorInit, Content: `u8R"(utf-8 raw string literal)"`},
+			expected: Token{Type: TokenType_Unassigned, Location: CursorInit, Content: `u8R"(utf-8 raw string literal)"`},
 		},
 		{
 			input:    []byte(`uR"(utf-16 raw string literal)"`),
-			expected: Token{Type: TokenType_LiteralRawString, Location: CursorInit, Content: `uR"(utf-16 raw string literal)"`},
+			expected: Token{Type: TokenType_Unassigned, Location: CursorInit, Content: `uR"(utf-16 raw string literal)"`},
 		},
 		{
 			input:    []byte(`UR"(utf-32 raw string literal)"`),
-			expected: Token{Type: TokenType_LiteralRawString, Location: CursorInit, Content: `UR"(utf-32 raw string literal)"`},
+			expected: Token{Type: TokenType_Unassigned, Location: CursorInit, Content: `UR"(utf-32 raw string literal)"`},
 		},
 		{
 			input:    []byte("identifier123;"),

--- a/language/internal/cc/lexer/token.go
+++ b/language/internal/cc/lexer/token.go
@@ -57,9 +57,6 @@ const (
 	// String literal, enclosed in double quotes, e.g. "example".
 	TokenType_LiteralString
 
-	// Raw string literal, enclosed in R"delimiter(...contents...)delimiter".
-	TokenType_LiteralRawString
-
 	// Single-line comment, starting with // and ending at the end of the line.
 	TokenType_CommentSingleLine
 
@@ -128,8 +125,6 @@ func (t TokenType) String() string {
 		return "integer literal"
 	case TokenType_LiteralString:
 		return `"string literal"`
-	case TokenType_LiteralRawString:
-		return `R"raw string literal"`
 	case TokenType_CommentSingleLine:
 		return "single-line comment"
 	case TokenType_CommentMultiLine:


### PR DESCRIPTION
C++ source may contain raw string literals, which should be treated as single tokens. See:
- New test cases in `parser_test.go`
- https://en.cppreference.com/w/cpp/language/string_literal.html