### PR TITLE
Revert "release: use specific hash for publish-to-bcr (#130)"

### DIFF
--- a/.github/workflows/publish-to-bcr.yaml
+++ b/.github/workflows/publish-to-bcr.yaml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   publish-to-bcr:
-    uses: "bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@1a42c3dca6566cf3a07689768259f1a35066ed01"
+    uses: "bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v0.2.3"
     with:
       tag_name: "${{ inputs.tag_name }}"
       registry_fork: "EngFlow/bazel-central-registry"


### PR DESCRIPTION
This reverts commit 1723d27c0a635b96e875129d12645cb5cd09df5c.

This broke attestation verification. The publish-to-bcr workflow is able
to create and attach an attestation, but BCR CI runs slsa-verifier,
which rejects the attestation. The builder ref must be a tag,
not a branch or commit. Not really sure why, but it seems to be
intentional. See
https://github.com/slsa-framework/slsa-verifier/blob/main/verifiers/internal/gha/builder.go#L93
