### PR TITLE
Generic return type for main function

### DIFF
--- a/language/internal/cc/parser/parser.go
+++ b/language/internal/cc/parser/parser.go
@@ -519,15 +519,6 @@ func (p *parser) parseDirective() (Directive, error) {
 	}
 }
 
-func isMainFunctionReturnType(ident string) bool {
-	switch ident {
-	case "auto", "int":
-		return true
-	default:
-		return false
-	}
-}
-
 func isMainFunctionIdentifier(ident string) bool {
 	switch ident {
 	case "main", "wmain", "_tmain", "WinMain", "wWinMain", "_tWinMain":
@@ -538,7 +529,7 @@ func isMainFunctionIdentifier(ident string) bool {
 }
 
 func (p *parser) tryParseMainFunction() bool {
-	if len(p.tokensLeft) >= 3 && isMainFunctionReturnType(p.tokensLeft[0].Content) && isMainFunctionIdentifier(p.tokensLeft[1].Content) && p.tokensLeft[2].Content == "(" {
+	if len(p.tokensLeft) >= 3 && p.tokensLeft[0].Type == lexer.TokenType_Identifier && isMainFunctionIdentifier(p.tokensLeft[1].Content) && p.tokensLeft[2].Type == lexer.TokenType_ParenthesisLeft {
 		p.dropTokens(3)
 		return true
 	}

--- a/language/internal/cc/parser/parser_test.go
+++ b/language/internal/cc/parser/parser_test.go
@@ -774,6 +774,13 @@ func TestParseSourceHasMain(t *testing.T) {
 			expected: true,
 			input:    "auto main() -> int {return 0;}",
 		},
+		{
+			expected: true,
+			input: `
+			using RetVal = int;
+			RetVal main() {}
+			`,
+		},
 	}
 
 	for idx, tc := range testCases {


### PR DESCRIPTION
In some cases, the return type of `main` may be different than explicit `int`.

# Trailing return type syntax

This is a legal syntax in C++:

```c++
auto main() -> int {
    return 0;
}
```

See: https://en.wikipedia.org/wiki/Trailing_return_type

# Type alias

Return type may be aliased while still defining a valid `main` function.

```c++
using RetVal = int;
RetVal main() {}
```