### PR TITLE
CI: publish prereleases to BCR

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,7 +36,6 @@ jobs:
       
   publish-to-bcr:
     needs: [release]
-    if: ${{ needs.release.result == 'success' }}
     uses: ./.github/workflows/publish-to-bcr.yaml
     with:
       tag_name: ${{ inputs.tag_name || github.ref_name }}


### PR DESCRIPTION
So that we don't burn a release semantic version when BCR testing fails.

Also, require that the release_ruleset.yaml job succeeds before publishing.
Previously, we established a dependency but didn't require success.
