### PR TITLE
Release presubmit: fix bazelisk versions

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -2,7 +2,7 @@ bcr_test_module:
   module_path: "example/bzlmod"
   matrix:
     platform: ["macos", "ubuntu2004"]
-    bazel: [7.x, 8.x, 9.x]
+    bazel: ["7.*", "8.*", "9.*"]
   tasks:
     run_tests:
       name: "Build and test the example module"


### PR DESCRIPTION
9.x is not a valid Bazelisk version because Bazel 9 is not released yet.
We need to use 9.* instead to select the next release or release candidate.

Signed-off-by: Jay Conrod <jay@engflow.com>
