### PR TITLE
Handle invalid expressions in preprocessor conditionals

### DIFF
--- a/language/internal/cc/parser/parser_test.go
+++ b/language/internal/cc/parser/parser_test.go
@@ -710,6 +710,28 @@ func TestParseConditionalIncludes(t *testing.T) {
 				"13:4: missing directive '#endif' for directive '#ifdef'",
 			},
 		},
+		{
+			// Wrong usage of infix operator
+			input: `
+			#if A && B!
+			#endif
+			`,
+			expected: nil,
+			expectedErrors: []string{
+				"2:14: unexpected token(s) in expression: !",
+			},
+		},
+		{
+			// Unsupported operator
+			input: `
+			#if A + B < C
+			#endif
+			`,
+			expected: nil,
+			expectedErrors: []string{
+				"2:10: unexpected token(s) in expression: + B < C",
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Fixes #151

- Check `rule.infixParser == nil`, so the code won't panic anymore.
- There may exist extra tokens after parsing a complete expression, which is now considered an error.