### PR TITLE
Improve header path stripping to support CMake → Bazel migration

### DIFF
--- a/language/cc/config.go
+++ b/language/cc/config.go
@@ -144,10 +144,6 @@ func (c *ccLanguage) Configure(config *config.Config, rel string, f *rule.File) 
 						log.Printf("# gazelle:cc_search: strip_include_prefix path %q is not clean", s.stripIncludePrefix)
 						continue
 					}
-					if path.IsAbs(s.stripIncludePrefix) {
-						log.Printf("# gazelle:cc_search: strip_include_prefix path %q must be relative", s.stripIncludePrefix)
-						continue
-					}
 				}
 				if len(args) > 1 {
 					s.includePrefix = args[1]

--- a/language/cc/generate.go
+++ b/language/cc/generate.go
@@ -141,7 +141,7 @@ func splitSourcesIntoGroups(args language.GenerateArgs, fileInfos []fileInfo) so
 		}
 		srcGroups = sourceGroups{groupId(groupName): {sources: fileInfos}}
 	case groupSourcesByUnit:
-		srcGroups = groupSourcesByUnits(args.Rel, conf.ccStripIncludePrefix, conf.ccIncludePrefix, fileInfos)
+		srcGroups = groupSourcesByUnits(args.Rel, conf.ccStripIncludePrefix, conf.ccIncludePrefix, conf.ccSearch, fileInfos)
 	}
 	return srcGroups
 }

--- a/language/cc/resolve_test.go
+++ b/language/cc/resolve_test.go
@@ -17,6 +17,9 @@ package cc
 import (
 	"testing"
 
+	"github.com/bazelbuild/bazel-gazelle/config"
+	"github.com/bazelbuild/bazel-gazelle/resolve"
+	"github.com/bazelbuild/bazel-gazelle/rule"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -64,5 +67,279 @@ func TestTransformIncludePath(t *testing.T) {
 	for _, tc := range testCases {
 		result := transformIncludePath(libRel, tc.stripIncludePrefix, tc.includePrefix, hdrRel)
 		assert.Equal(t, tc.expectedResult, result, "stripIncludePrefix=%q, includePrefix=%q", tc.stripIncludePrefix, tc.includePrefix)
+	}
+}
+
+func TestImports(t *testing.T) {
+	lang := &ccLanguage{}
+
+	testCases := []struct {
+		name            string
+		ruleKind        string
+		ruleAttrs       map[string]interface{}
+		rulePrivate     map[string]interface{}
+		pkg             string
+		ccSearch        []ccSearch
+		expectedImports []resolve.ImportSpec
+	}{
+		{
+			name:     "cc_proto_library with proto files",
+			ruleKind: "cc_proto_library",
+			rulePrivate: map[string]interface{}{
+				ccProtoLibraryFilesKey: []string{"foo.proto", "bar.proto"},
+			},
+			pkg: "pkg",
+			expectedImports: []resolve.ImportSpec{
+				{Lang: languageName, Imp: "pkg/foo.pb.h"},
+				{Lang: languageName, Imp: "pkg/bar.pb.h"},
+			},
+		},
+		{
+			name:            "cc_proto_library without private attr",
+			ruleKind:        "cc_proto_library",
+			pkg:             "pkg",
+			expectedImports: []resolve.ImportSpec{},
+		},
+		{
+			name:     "cc_library with basic hdrs",
+			ruleKind: "cc_library",
+			ruleAttrs: map[string]interface{}{
+				"hdrs": []string{"foo.h", "bar.h"},
+			},
+			pkg: "pkg",
+			expectedImports: []resolve.ImportSpec{
+				{Lang: languageName, Imp: "pkg/foo.h"},
+				{Lang: languageName, Imp: "pkg/bar.h"},
+			},
+		},
+		{
+			name:     "cc_library with strip_include_prefix",
+			ruleKind: "cc_library",
+			ruleAttrs: map[string]interface{}{
+				"hdrs":                 []string{"include/foo.h"},
+				"strip_include_prefix": "pkg/include",
+			},
+			pkg: "pkg",
+			expectedImports: []resolve.ImportSpec{
+				{Lang: languageName, Imp: "pkg/include/foo.h"},
+			},
+		},
+		{
+			name:     "cc_library with include_prefix",
+			ruleKind: "cc_library",
+			ruleAttrs: map[string]interface{}{
+				"hdrs":           []string{"foo.h"},
+				"include_prefix": "extra",
+			},
+			pkg: "pkg",
+			expectedImports: []resolve.ImportSpec{
+				{Lang: languageName, Imp: "pkg/foo.h"},
+				{Lang: languageName, Imp: "extra/foo.h"},
+			},
+		},
+		{
+			name:     "cc_library with includes",
+			ruleKind: "cc_library",
+			ruleAttrs: map[string]interface{}{
+				"hdrs":     []string{"include/foo.h"},
+				"includes": []string{"include"},
+			},
+			pkg: "pkg",
+			expectedImports: []resolve.ImportSpec{
+				{Lang: languageName, Imp: "pkg/include/foo.h"},
+				{Lang: languageName, Imp: "foo.h"},
+			},
+		},
+		{
+			name:     "cc_library with includes dot",
+			ruleKind: "cc_library",
+			ruleAttrs: map[string]interface{}{
+				"hdrs":     []string{"foo.h"},
+				"includes": []string{"."},
+			},
+			pkg: "pkg",
+			expectedImports: []resolve.ImportSpec{
+				{Lang: languageName, Imp: "pkg/foo.h"},
+				{Lang: languageName, Imp: "foo.h"},
+			},
+		},
+		{
+			name:     "cc_library with cc_search",
+			ruleKind: "cc_library",
+			ruleAttrs: map[string]interface{}{
+				"hdrs": []string{"src/include/foo.h"},
+			},
+			pkg: "pkg",
+			ccSearch: []ccSearch{
+				{stripIncludePrefix: "pkg/src/include", includePrefix: ""},
+			},
+			expectedImports: []resolve.ImportSpec{
+				{Lang: languageName, Imp: "pkg/src/include/foo.h"},
+				{Lang: languageName, Imp: "foo.h"},
+			},
+		},
+		{
+			name:     "cc_library with cc_search absolute path",
+			ruleKind: "cc_library",
+			ruleAttrs: map[string]interface{}{
+				"hdrs": []string{"src/include/foo.h"},
+			},
+			pkg: "pkg",
+			ccSearch: []ccSearch{
+				{stripIncludePrefix: "/pkg/src/include", includePrefix: ""},
+			},
+			expectedImports: []resolve.ImportSpec{
+				{Lang: languageName, Imp: "pkg/src/include/foo.h"},
+				{Lang: languageName, Imp: "foo.h"},
+			},
+		},
+		{
+			name:     "cc_library with cc_search and include_prefix",
+			ruleKind: "cc_library",
+			ruleAttrs: map[string]interface{}{
+				"hdrs": []string{"src/include/foo.h"},
+			},
+			pkg: "pkg",
+			ccSearch: []ccSearch{
+				{stripIncludePrefix: "pkg/src/include", includePrefix: "extra"},
+			},
+			expectedImports: []resolve.ImportSpec{
+				{Lang: languageName, Imp: "pkg/src/include/foo.h"},
+				{Lang: languageName, Imp: "foo.h"},
+			},
+		},
+		{
+			name:     "cc_library with includes and cc_search",
+			ruleKind: "cc_library",
+			ruleAttrs: map[string]interface{}{
+				"hdrs":     []string{"include/foo.h"},
+				"includes": []string{"include"},
+			},
+			pkg: "pkg",
+			ccSearch: []ccSearch{
+				{stripIncludePrefix: "pkg/include", includePrefix: ""},
+			},
+			expectedImports: []resolve.ImportSpec{
+				{Lang: languageName, Imp: "pkg/include/foo.h"},
+				{Lang: languageName, Imp: "foo.h"},
+			},
+		},
+		{
+			name:     "cc_library with multiple cc_search",
+			ruleKind: "cc_library",
+			ruleAttrs: map[string]interface{}{
+				"hdrs": []string{"src/include/foo.h"},
+			},
+			pkg: "pkg",
+			ccSearch: []ccSearch{
+				{stripIncludePrefix: "pkg/src/include", includePrefix: ""},
+				{stripIncludePrefix: "pkg/src", includePrefix: ""},
+			},
+			expectedImports: []resolve.ImportSpec{
+				{Lang: languageName, Imp: "pkg/src/include/foo.h"},
+				{Lang: languageName, Imp: "foo.h"},
+				{Lang: languageName, Imp: "include/foo.h"},
+			},
+		},
+		{
+			name:     "cc_library with strip_include_prefix and include_prefix",
+			ruleKind: "cc_library",
+			ruleAttrs: map[string]interface{}{
+				"hdrs":                 []string{"include/foo.h"},
+				"strip_include_prefix": "pkg/include",
+				"include_prefix":       "extra",
+			},
+			pkg: "pkg",
+			expectedImports: []resolve.ImportSpec{
+				{Lang: languageName, Imp: "pkg/include/foo.h"},
+				{Lang: languageName, Imp: "extra/pkg/include/foo.h"},
+			},
+		},
+		{
+			name:     "cc_library with all attributes",
+			ruleKind: "cc_library",
+			ruleAttrs: map[string]interface{}{
+				"hdrs":                 []string{"include/foo.h"},
+				"strip_include_prefix": "pkg/include",
+				"include_prefix":       "extra",
+				"includes":             []string{"include"},
+			},
+			pkg: "pkg",
+			expectedImports: []resolve.ImportSpec{
+				{Lang: languageName, Imp: "pkg/include/foo.h"},
+				{Lang: languageName, Imp: "extra/pkg/include/foo.h"},
+				{Lang: languageName, Imp: "foo.h"},
+			},
+		},
+		{
+			name:     "cc_library with non-matching cc_search",
+			ruleKind: "cc_library",
+			ruleAttrs: map[string]interface{}{
+				"hdrs": []string{"foo.h"},
+			},
+			pkg: "pkg",
+			ccSearch: []ccSearch{
+				{stripIncludePrefix: "other/pkg", includePrefix: ""},
+			},
+			expectedImports: []resolve.ImportSpec{
+				{Lang: languageName, Imp: "pkg/foo.h"},
+			},
+		},
+		{
+			name:     "cc_library with empty cc_search stripIncludePrefix",
+			ruleKind: "cc_library",
+			ruleAttrs: map[string]interface{}{
+				"hdrs": []string{"foo.h"},
+			},
+			pkg: "pkg",
+			ccSearch: []ccSearch{
+				{stripIncludePrefix: "", includePrefix: ""},
+			},
+			expectedImports: []resolve.ImportSpec{
+				{Lang: languageName, Imp: "pkg/foo.h"},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create config
+			cfg := &config.Config{}
+			cfg.Exts = make(map[string]interface{})
+			ccConfig := newCcConfig()
+			ccConfig.ccSearch = tc.ccSearch
+			cfg.Exts[languageName] = ccConfig
+
+			// Create rule
+			r := rule.NewRule(tc.ruleKind, "test_rule")
+			for k, v := range tc.ruleAttrs {
+				r.SetAttr(k, v)
+			}
+			for k, v := range tc.rulePrivate {
+				r.SetPrivateAttr(k, v)
+			}
+
+			// Create file
+			f := &rule.File{
+				Pkg: tc.pkg,
+			}
+
+			// Call Imports
+			imports := lang.Imports(cfg, r, f)
+
+			// Verify imports
+			assert.Equal(t, len(tc.expectedImports), len(imports), "Expected %d imports, got %d", len(tc.expectedImports), len(imports))
+
+			// Create a map for easier comparison
+			importMap := make(map[string]bool)
+			for _, imp := range imports {
+				importMap[imp.Imp] = true
+			}
+
+			for _, expected := range tc.expectedImports {
+				assert.True(t, importMap[expected.Imp], "Expected import %q not found. Got: %v", expected.Imp, imports)
+				assert.Equal(t, expected.Lang, languageName)
+			}
+		})
 	}
 }

--- a/language/cc/source_groups_test.go
+++ b/language/cc/source_groups_test.go
@@ -28,6 +28,7 @@ func TestSourceGroups(t *testing.T) {
 		rel                string
 		stripIncludePrefix string
 		includePrefix      string
+		ccSearch           []ccSearch
 		input              []fileInfo
 		expected           []sourceGroupSummary
 	}{
@@ -203,11 +204,28 @@ func TestSourceGroups(t *testing.T) {
 				{id: "a", sources: []string{"a.cc", "a.h", "b.cc", "b.h"}},
 			},
 		},
+		{
+			desc: "cc_search applies to full include paths",
+			rel:  "src",
+			ccSearch: []ccSearch{
+				{stripIncludePrefix: "/src/include", includePrefix: ""},
+			},
+			input: []fileInfo{
+				fileInfoForTest("a.h"),
+				fileInfoForTest("a.cc", "foo/b.h", "src/include/a.h"),
+				fileInfoForTest("b.h"),
+				fileInfoForTest("b.cc", "src/include/a.h", "src/include/b.h"),
+			},
+			expected: []sourceGroupSummary{
+				{id: "a", sources: []string{"a.cc", "a.h"}},
+				{id: "b", sources: []string{"b.cc", "b.h"}},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			actual := summarizeSourceGroups(groupSourcesByUnits(tc.rel, tc.stripIncludePrefix, tc.includePrefix, tc.input))
+			actual := summarizeSourceGroups(groupSourcesByUnits(tc.rel, tc.stripIncludePrefix, tc.includePrefix, tc.ccSearch, tc.input))
 			assert.Equal(t, tc.expected, actual)
 		})
 	}


### PR DESCRIPTION
We are in the process of migrating our project from CMake to Bazel. Happy to see this project. Due to the extensive use of include_directories in the existing CMake configuration, many include paths are not absolute. This requires us to strip multiple possible prefixes when resolving header dependencies. Relying on a **single stripIncludePrefixis** not sufficient in this case. This PR improves the stripping logic to better support this migration and make header resolution more reliable.

## Example
```
├── BUILD
├── cmake
│   ├── include
│   │   ├── a.h
│   └── src
│       ├── a.cc
├── MODULE.bazel

$cat cmake/src/a.cc 
#include "a.h"
```
### Before
`gazelle: @gazelle_cc_example//cmake/src:a: could not find a library providing header - '#include "a.h"' at cmake/src/a.cc:1`

```
$cat cmake/src/BUILD.bazel
cc_library(
    name = "a",
    srcs = ["a.cc"],
    visibility = ["//visibility:public"],
)
```

### Now
BUILD.bazel
`# gazelle:cc_search /cmake/include`

```
$cat cmake/src/BUILD.bazel
cc_library(
    name = "a",
    srcs = ["a.cc"],
    implementation_deps = ["//cmake/include:a"],  // new
    visibility = ["//visibility:public"],
)
```