### PR TITLE
Optimize Cursor rules

### DIFF
--- a/.cursor/rules/build.mdc
+++ b/.cursor/rules/build.mdc
@@ -1,6 +1,6 @@
 ---
 description: What's the build structure of the project and how to traverse through the code
-alwaysApply: true
+globs: **/*.bzl,**/*.bazel,**/BUILD,**/WORKSPACE
 ---
 # Build structure
 

--- a/.cursor/rules/integration-tests.mdc
+++ b/.cursor/rules/integration-tests.mdc
@@ -1,8 +1,8 @@
 ---
-description: How to run tests in this project and how the testing framework works
-alwaysApply: true
+description: How to run and write integration tests in this project
+globs: language/cc/testdata/**
 ---
-# Testing
+# Integration tests
 
 ## Running tests
 
@@ -17,24 +17,6 @@ alwaysApply: true
 - All scenarios under `language/cc/testdata/` must be covered by `gazelle_generation_test`.
 - By default, a scenario should be covered by `gazelle_compilation_test`, unless the scenario is not compilable by design, because of, e.g., unresolved `cc_library` dependencies.
 
-## Adding tests
-
-### Integration tests
+## Adding integration tests
 
 - In case of new `gazelle_cc` features, especially new/modified directives defined in `func (c *ccLanguage) KnownDirectives() []string`, add an appropriate test scenario under `language/cc/testdata/`.
-
-### Unit tests
-
-- For testing generic logic add/update `*_test.go` file.
-- Test files must be wrapped with `go_test` Bazel rule. Use the same Go package as the tested Go library. Place the tested `go_library` dependency under the `"embed"` attribute of `go_test`.
-- Prefer using [assert](https://pkg.go.dev/github.com/stretchr/testify/assert) and [require](https://pkg.go.dev/github.com/stretchr/testify/require) packages to raw [`testing.T.Fail`](https://pkg.go.dev/testing#T.Fail) calls.
-- Use [`testing.T.Run`](https://pkg.go.dev/testing#T.Run) to associate test cases with their descriptions.
-- Organize test cases within a `Test*` function into a slice of structs:
-```go
-testCases := []struct {
-    description string
-    // test case args ...
-} {
-    // ...
-}
-```

--- a/.cursor/rules/style.mdc
+++ b/.cursor/rules/style.mdc
@@ -1,6 +1,6 @@
 ---
 description: Code style and structure guidelines for this project
-alwaysApply: true
+globs: **/*.go
 ---
 # Code style guidelines
 

--- a/.cursor/rules/unit-tests.mdc
+++ b/.cursor/rules/unit-tests.mdc
@@ -1,0 +1,26 @@
+---
+description: How to run and write unit tests in this project
+globs: **/*_test.go
+---
+# Unit tests
+
+## Running tests
+
+- Use the command `bazel test //...` to run all tests.
+- `example/` directory contains slow end-to-end tests that can only be run manually by the `.github/workflows/test_e2e.sh` script.
+
+## Adding unit tests
+
+- For testing generic logic add/update `*_test.go` file.
+- Test files must be wrapped with `go_test` Bazel rule. Use the same Go package as the tested Go library. Place the tested `go_library` dependency under the `"embed"` attribute of `go_test`.
+- Prefer using [assert](https://pkg.go.dev/github.com/stretchr/testify/assert) and [require](https://pkg.go.dev/github.com/stretchr/testify/require) packages to raw [`testing.T.Fail`](https://pkg.go.dev/testing#T.Fail) calls.
+- Use [`testing.T.Run`](https://pkg.go.dev/testing#T.Run) to associate test cases with their descriptions.
+- Organize test cases within a `Test*` function into a slice of structs:
+```go
+testCases := []struct {
+    description string
+    // test case args ...
+} {
+    // ...
+}
+```


### PR DESCRIPTION
`alwaysApply: true` pollutes the context regardless of whether it's relevant to the current task. `globs` applies the rule only when specified files are mentioned/affected in a conversation. I've also split _testing_ into _unit-tests_ and _integration-tests_. This should lead to more relevant rule application during conversation.

All of this requires a lot of experimenting and, of course, may change in the future.