### PR TITLE
Update CI workflow to use the latest versions of the actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
       USE_BAZEL_VERSION: ${{ matrix.bazel-version }}
       BAZELRC: ${{ matrix.custom-bazelrc }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Build
         run: |
           bazel build //...
@@ -52,7 +52,7 @@ jobs:
       run:
         working-directory: "example/bzlmod"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Run Gazelle
         run: "bazel run //:gazelle"
       - name: Build
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Install Conan
       run: |
         python3 -m pip install --upgrade pip
@@ -76,7 +76,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
-    - uses: actions/checkout@v4  
+    - uses: actions/checkout@v6
     - name: Execute end to end tests
       run: bash .github/workflows/test_e2e.sh
           
@@ -84,5 +84,5 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: ./scripts/license_check.sh 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - main 
+      - main
 
 concurrency:
   group: ci-${{ github.head_ref }}-${{ github.event_name }}
@@ -64,25 +64,25 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
-    - uses: actions/checkout@v6
-    - name: Install Conan
-      run: |
-        python3 -m pip install --upgrade pip
-        pip install conan
-    - name: Execute manual integration tests
-      run: bazel test --test_output=errors //index:integration_tests
-          
+      - uses: actions/checkout@v6
+      - name: Install Conan
+        run: |
+          python3 -m pip install --upgrade pip
+          pip install conan
+      - name: Execute manual integration tests
+        run: bazel test --test_output=errors //index:integration_tests
+
   test-e2e:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
-    - uses: actions/checkout@v6
-    - name: Execute end to end tests
-      run: bash .github/workflows/test_e2e.sh
-          
+      - uses: actions/checkout@v6
+      - name: Execute end to end tests
+        run: bash .github/workflows/test_e2e.sh
+
   license-headers:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
-      - run: ./scripts/license_check.sh 
+      - run: ./scripts/license_check.sh

--- a/.github/workflows/generate_bzldep_index.yaml
+++ b/.github/workflows/generate_bzldep_index.yaml
@@ -13,14 +13,14 @@ jobs:
   build-plan:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: coursier/cache-action@v6     
-      - uses: coursier/setup-action@v1
+      - uses: actions/checkout@v6
+      - uses: coursier/cache-action@v8
+      - uses: coursier/setup-action@v3
         with:
           apps: scala
           
       # Reuse already resolved info if available
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: .cache/
           key: gen-mappings-indexer-cache

--- a/.github/workflows/generate_bzldep_index.yaml
+++ b/.github/workflows/generate_bzldep_index.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: coursier/setup-action@v3
         with:
           apps: scala
-          
+
       # Reuse already resolved info if available
       - uses: actions/cache@v5
         with:
@@ -31,7 +31,7 @@ jobs:
           --recompute-unresolved \
           --cache-dir=$PWD/.cache \
           -v
-        
+
       - name: Create PR
         env:
           GH_TOKEN: ${{ github.token }}
@@ -42,18 +42,17 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git checkout -b $branchName
           git add ./language/cc/bzldep-index.json
-          
+
           if git diff --cached --quiet; then
             echo "No changes to the index file, skipping PR creation"
             exit 0
           fi
-          
+
           git commit -m "Automated update of headers index based on bazel-central-registry"
           git push origin $branchName
-          
+
           gh pr create \
             --base=main \
             --head=$branchName \
             --title='[Bot] Update bazel-central-registry headers index' \
             --fill
-        

--- a/.github/workflows/publish-to-bcr.yaml
+++ b/.github/workflows/publish-to-bcr.yaml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   publish-to-bcr:
-    uses: "bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v1"
+    uses: "bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v1.1.0"
     with:
       tag_name: "${{ inputs.tag_name }}"
       registry_fork: "EngFlow/bazel-central-registry"

--- a/.github/workflows/publish-to-bcr.yaml
+++ b/.github/workflows/publish-to-bcr.yaml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   publish-to-bcr:
-    uses: "bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v0.2.3"
+    uses: "bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v1"
     with:
       tag_name: "${{ inputs.tag_name }}"
       registry_fork: "EngFlow/bazel-central-registry"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,7 +33,7 @@ jobs:
       prerelease: false
       release_files: gazelle_cc-*.tar.gz
       tag_name: ${{ inputs.tag_name || github.ref_name }}
-      
+
   publish-to-bcr:
     needs: [release]
     uses: ./.github/workflows/publish-to-bcr.yaml


### PR DESCRIPTION
I can see the following message in the GitHub Actions dashboard:

> Warning: Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

So I updated all the actions to their newest versions available.