### PR TITLE
Fix Protobuf header resolution with import_path, strip_import_path

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -74,6 +74,7 @@ use_repo(
     "compilation_test_protobuf",
     "compilation_test_protobuf_empty",
     "compilation_test_protobuf_filter_generated",
+    "compilation_test_protobuf_import_prefix",
     "compilation_test_relative_inlcude_paths",
     "compilation_test_rules_cleanup",
     "compilation_test_rules_with_no_sources",

--- a/language/cc/resolve.go
+++ b/language/cc/resolve.go
@@ -20,6 +20,7 @@ import (
 	"log"
 	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/EngFlow/gazelle_cc/internal/collections"
 	"github.com/bazelbuild/bazel-gazelle/config"
@@ -283,6 +284,37 @@ func (lang *ccLanguage) resolveImportSpec(
 
 		resolvedDeps := collections.MapSlice(importedRules, func(r resolve.FindResult) label.Label { return r.Label })
 		return resolveAmbiguousDependency(resolvedDeps, conf.ambiguousDepsMode, r, from, include)
+	}
+
+	// Resolve Protobuf libraries
+	//
+	// These libraries may have different paths than what we computed if they use
+	// `gazelle:proto_import_path` or `gazelle:proto_strip_import_path`, so we use the `proto`
+	// rule resolution and convert back to C++.
+	pbSuffixes := []string{".pb.h", ".grpc.pb.h"}
+
+	for _, pbSuffix := range pbSuffixes {
+		if stripped, ok := strings.CutSuffix(importSpec.Imp, pbSuffix); ok {
+			pbSpec := resolve.ImportSpec{
+				Lang: "proto",
+				Imp: stripped + ".proto",
+			}
+
+			if importedRules := ix.FindRulesByImportWithConfig(c, pbSpec, "proto"); len(importedRules) > 0 {
+				ruleSuffix := "_cc_proto"
+
+				if pbSuffix == ".grpc.pb.h" {
+					ruleSuffix = "_cc_grpc"
+				}
+
+				resolvedDeps := collections.MapSlice(importedRules, func(r resolve.FindResult) label.Label {
+					ccLabel := r.Label
+					ccLabel.Name = strings.TrimSuffix(ccLabel.Name, "_proto") + ruleSuffix
+					return ccLabel
+				})
+				return resolveAmbiguousDependency(resolvedDeps, conf.ambiguousDepsMode, r, from, include)
+			}
+		}
 	}
 
 	for _, index := range conf.dependencyIndexes {

--- a/language/cc/testdata/protobuf_import_prefix/MODULE.bazel
+++ b/language/cc/testdata/protobuf_import_prefix/MODULE.bazel
@@ -1,0 +1,1 @@
+bazel_dep(name = "protobuf", version = "", repo_name = "com_google_protobuf")

--- a/language/cc/testdata/protobuf_import_prefix/dir/BUILD.in
+++ b/language/cc/testdata/protobuf_import_prefix/dir/BUILD.in
@@ -2,18 +2,16 @@ load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
 load("@rules_cc//cc:defs.bzl", "cc_binary")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 
-# gazelle:proto file
-
 proto_library(
-    name = "a_proto",
+    name = "dir_proto",
     srcs = ["a.proto"],
     visibility = ["//visibility:public"],
 )
 
 cc_proto_library(
-    name = "a_cc_proto",
+    name = "dir_cc_proto",
     visibility = ["//visibility:public"],
-    deps = [":a_proto"],
+    deps = [":dir_proto"],
 )
 
 cc_binary(

--- a/language/cc/testdata/protobuf_import_prefix/dir/BUILD.in
+++ b/language/cc/testdata/protobuf_import_prefix/dir/BUILD.in
@@ -1,0 +1,22 @@
+load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+# gazelle:proto file
+
+proto_library(
+    name = "a_proto",
+    srcs = ["a.proto"],
+    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "a_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":a_proto"],
+)
+
+cc_binary(
+    name = "main",
+    srcs = ["main.cc"],
+)

--- a/language/cc/testdata/protobuf_import_prefix/dir/BUILD.out
+++ b/language/cc/testdata/protobuf_import_prefix/dir/BUILD.out
@@ -1,0 +1,28 @@
+load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+# gazelle:proto file
+
+proto_library(
+    name = "a_proto",
+    srcs = ["a.proto"],
+    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "a_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":a_proto"],
+)
+
+cc_binary(
+    name = "main",
+    srcs = ["main.cc"],
+    deps = [
+        ":a_cc_proto",
+        "//dir/with_import_prefix:b_cc_proto",
+        "//stripped_abs_prefix/subpackage:c_cc_proto",
+        "//stripped_abs_prefix/subpackage/with_import_prefix:d_cc_proto",
+    ],
+)

--- a/language/cc/testdata/protobuf_import_prefix/dir/BUILD.out
+++ b/language/cc/testdata/protobuf_import_prefix/dir/BUILD.out
@@ -2,25 +2,23 @@ load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
 load("@rules_cc//cc:defs.bzl", "cc_binary")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 
-# gazelle:proto file
-
 proto_library(
-    name = "a_proto",
+    name = "dir_proto",
     srcs = ["a.proto"],
     visibility = ["//visibility:public"],
 )
 
 cc_proto_library(
-    name = "a_cc_proto",
+    name = "dir_cc_proto",
     visibility = ["//visibility:public"],
-    deps = [":a_proto"],
+    deps = [":dir_proto"],
 )
 
 cc_binary(
     name = "main",
     srcs = ["main.cc"],
     deps = [
-        ":a_cc_proto",
+        ":dir_cc_proto",
         "//dir/with_import_prefix:b_cc_proto",
         "//stripped_abs_prefix/subpackage:c_cc_proto",
         "//stripped_abs_prefix/subpackage/with_import_prefix:d_cc_proto",

--- a/language/cc/testdata/protobuf_import_prefix/dir/a.proto
+++ b/language/cc/testdata/protobuf_import_prefix/dir/a.proto
@@ -1,0 +1,3 @@
+syntax = "proto3";
+
+package a;

--- a/language/cc/testdata/protobuf_import_prefix/dir/a.proto
+++ b/language/cc/testdata/protobuf_import_prefix/dir/a.proto
@@ -1,3 +1,3 @@
 syntax = "proto3";
 
-package a;
+package dir;

--- a/language/cc/testdata/protobuf_import_prefix/dir/main.cc
+++ b/language/cc/testdata/protobuf_import_prefix/dir/main.cc
@@ -1,0 +1,6 @@
+#include "dir/a.pb.h"
+#include "proto/dir/with_import_prefix/b.pb.h"
+#include "proto/subpackage/with_import_prefix/d.pb.h"
+#include "subpackage/c.pb.h"
+
+int main() {}

--- a/language/cc/testdata/protobuf_import_prefix/dir/with_import_prefix/BUILD.in
+++ b/language/cc/testdata/protobuf_import_prefix/dir/with_import_prefix/BUILD.in
@@ -1,0 +1,17 @@
+load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+# gazelle:proto_import_prefix proto
+
+proto_library(
+    name = "b_proto",
+    srcs = ["b.proto"],
+    import_prefix = "proto",
+    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "b_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":b_proto"],
+)

--- a/language/cc/testdata/protobuf_import_prefix/dir/with_import_prefix/BUILD.in
+++ b/language/cc/testdata/protobuf_import_prefix/dir/with_import_prefix/BUILD.in
@@ -1,6 +1,7 @@
 load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 
+# gazelle:proto file
 # gazelle:proto_import_prefix proto
 
 proto_library(

--- a/language/cc/testdata/protobuf_import_prefix/dir/with_import_prefix/BUILD.out
+++ b/language/cc/testdata/protobuf_import_prefix/dir/with_import_prefix/BUILD.out
@@ -1,0 +1,17 @@
+load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+# gazelle:proto_import_prefix proto
+
+proto_library(
+    name = "b_proto",
+    srcs = ["b.proto"],
+    import_prefix = "proto",
+    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "b_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":b_proto"],
+)

--- a/language/cc/testdata/protobuf_import_prefix/dir/with_import_prefix/BUILD.out
+++ b/language/cc/testdata/protobuf_import_prefix/dir/with_import_prefix/BUILD.out
@@ -1,6 +1,7 @@
 load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 
+# gazelle:proto file
 # gazelle:proto_import_prefix proto
 
 proto_library(

--- a/language/cc/testdata/protobuf_import_prefix/dir/with_import_prefix/b.proto
+++ b/language/cc/testdata/protobuf_import_prefix/dir/with_import_prefix/b.proto
@@ -1,0 +1,3 @@
+syntax = "proto3";
+
+package b;

--- a/language/cc/testdata/protobuf_import_prefix/stripped_abs_prefix/subpackage/BUILD.in
+++ b/language/cc/testdata/protobuf_import_prefix/stripped_abs_prefix/subpackage/BUILD.in
@@ -1,0 +1,24 @@
+load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+# gazelle:proto file
+# gazelle:proto_strip_import_prefix /stripped_abs_prefix
+
+proto_library(
+    name = "c_proto",
+    srcs = ["c.proto"],
+    strip_import_prefix = "/stripped_abs_prefix",
+    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "c_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":c_proto"],
+)
+
+cc_binary(
+    name = "main",
+    srcs = ["main.cc"],
+)

--- a/language/cc/testdata/protobuf_import_prefix/stripped_abs_prefix/subpackage/BUILD.out
+++ b/language/cc/testdata/protobuf_import_prefix/stripped_abs_prefix/subpackage/BUILD.out
@@ -1,0 +1,30 @@
+load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+# gazelle:proto file
+# gazelle:proto_strip_import_prefix /stripped_abs_prefix
+
+proto_library(
+    name = "c_proto",
+    srcs = ["c.proto"],
+    strip_import_prefix = "/stripped_abs_prefix",
+    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "c_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":c_proto"],
+)
+
+cc_binary(
+    name = "main",
+    srcs = ["main.cc"],
+    deps = [
+        ":c_cc_proto",
+        "//dir:a_cc_proto",
+        "//dir/with_import_prefix:b_cc_proto",
+        "//stripped_abs_prefix/subpackage/with_import_prefix:d_cc_proto",
+    ],
+)

--- a/language/cc/testdata/protobuf_import_prefix/stripped_abs_prefix/subpackage/BUILD.out
+++ b/language/cc/testdata/protobuf_import_prefix/stripped_abs_prefix/subpackage/BUILD.out
@@ -23,7 +23,7 @@ cc_binary(
     srcs = ["main.cc"],
     deps = [
         ":c_cc_proto",
-        "//dir:a_cc_proto",
+        "//dir:dir_cc_proto",
         "//dir/with_import_prefix:b_cc_proto",
         "//stripped_abs_prefix/subpackage/with_import_prefix:d_cc_proto",
     ],

--- a/language/cc/testdata/protobuf_import_prefix/stripped_abs_prefix/subpackage/c.proto
+++ b/language/cc/testdata/protobuf_import_prefix/stripped_abs_prefix/subpackage/c.proto
@@ -1,0 +1,3 @@
+syntax = "proto3";
+
+package c;

--- a/language/cc/testdata/protobuf_import_prefix/stripped_abs_prefix/subpackage/main.cc
+++ b/language/cc/testdata/protobuf_import_prefix/stripped_abs_prefix/subpackage/main.cc
@@ -1,0 +1,6 @@
+#include "dir/a.pb.h"
+#include "proto/dir/with_import_prefix/b.pb.h"
+#include "proto/subpackage/with_import_prefix/d.pb.h"
+#include "subpackage/c.pb.h"
+
+int main() {}

--- a/language/cc/testdata/protobuf_import_prefix/stripped_abs_prefix/subpackage/with_import_prefix/BUILD.in
+++ b/language/cc/testdata/protobuf_import_prefix/stripped_abs_prefix/subpackage/with_import_prefix/BUILD.in
@@ -1,0 +1,17 @@
+load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+# gazelle:proto_import_prefix proto
+
+proto_library(
+    name = "d_proto",
+    srcs = ["d.proto"],
+    import_prefix = "proto",
+    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "d_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":d_proto"],
+)

--- a/language/cc/testdata/protobuf_import_prefix/stripped_abs_prefix/subpackage/with_import_prefix/BUILD.out
+++ b/language/cc/testdata/protobuf_import_prefix/stripped_abs_prefix/subpackage/with_import_prefix/BUILD.out
@@ -1,0 +1,18 @@
+load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+# gazelle:proto_import_prefix proto
+
+proto_library(
+    name = "d_proto",
+    srcs = ["d.proto"],
+    import_prefix = "proto",
+    strip_import_prefix = "/stripped_abs_prefix",
+    visibility = ["//visibility:public"],
+)
+
+cc_proto_library(
+    name = "d_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = [":d_proto"],
+)

--- a/language/cc/testdata/protobuf_import_prefix/stripped_abs_prefix/subpackage/with_import_prefix/d.proto
+++ b/language/cc/testdata/protobuf_import_prefix/stripped_abs_prefix/subpackage/with_import_prefix/d.proto
@@ -1,0 +1,3 @@
+syntax = "proto3";
+
+package d;


### PR DESCRIPTION
This relies on translating the include paths from `foo/bar.pb.h` to `foo/bar.proto` and then using the `proto` import resolution. I originally tried to implement the whole logic by parsing `gazelle:proto_{strip_,}import_path` and applying it when we generate rules, but it was more complex, more fragile, and didn't work in all the cases tested in this commit.