### PR TITLE
CI: enable remote caching conditionally

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,7 @@ concurrency:
 
 env:
   OPAL_RPC_CREDENTIALS: ${{ secrets.OPAL_RPC_CREDENTIALS }}
+  BAZEL_CONFIG: ${{ secrets.OPAL_RPC_CREDENTIALS != '' && '--config=engflow' || '' }}
 
 jobs:
   build:
@@ -36,14 +37,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: "Set up authentication"
+        if: ${{ env.OPAL_RPC_CREDENTIALS != '' }}
         shell: bash
         run: "cp .bazelrc.ci .bazelrc.user"
       - name: Build
         run: |
-          bazel build --config=engflow //...
+          bazel build ${{ env.BAZEL_CONFIG }} //...
       - name: Test
         run: |
-          bazel test --config=engflow --test_output=errors //...
+          bazel test ${{ env.BAZEL_CONFIG }} --test_output=errors //...
 
   # Imitate the BCR test in .bcr/presubmit.yml. Keep in sync.
   bcr_test_module:
@@ -62,14 +64,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: "Set up authentication"
+        if: ${{ env.OPAL_RPC_CREDENTIALS != '' }}
         shell: bash
         run: "cp .bazelrc.ci .bazelrc.user && cp ../../scripts/bazel_credential_helper.sh ."
       - name: Run Gazelle
-        run: "bazel run --config=engflow //:gazelle"
+        run: "bazel run ${{ env.BAZEL_CONFIG }} //:gazelle"
       - name: Build
-        run: "bazel build --config=engflow //..."
+        run: "bazel build ${{ env.BAZEL_CONFIG }} //..."
       - name: Test
-        run: "bazel test --config=engflow //..."
+        run: "bazel test ${{ env.BAZEL_CONFIG }} //..."
 
   test-indexers:
     runs-on: ubuntu-24.04
@@ -77,6 +80,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: "Set up authentication"
+        if: ${{ env.OPAL_RPC_CREDENTIALS != '' }}
         shell: bash
         run: "cp .bazelrc.ci .bazelrc.user"
       - name: Install Conan
@@ -84,7 +88,7 @@ jobs:
           python3 -m pip install --upgrade pip
           pip install conan
       - name: Execute manual integration tests
-        run: bazel test --config=engflow --test_output=errors //index:integration_tests
+        run: bazel test ${{ env.BAZEL_CONFIG }} --test_output=errors //index:integration_tests
 
   test-e2e:
     runs-on: ubuntu-24.04
@@ -92,6 +96,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: "Set up authentication"
+        if: ${{ env.OPAL_RPC_CREDENTIALS != '' }}
         shell: bash
         run: "cp .bazelrc.ci .bazelrc.user"
       - name: Execute end to end tests

--- a/.github/workflows/test_e2e.sh
+++ b/.github/workflows/test_e2e.sh
@@ -6,7 +6,7 @@ scriptDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 rootDir=$(realpath "$scriptDir/../..")
 
 BAZEL_CONFIG_FLAGS=(
-  --config=engflow
+  ${BAZEL_CONFIG:-}
 )
 
 function runBazelCommandTreatingWarningsAsErrors() {


### PR DESCRIPTION
The OPAL_RPC_CREDENTIALS secret is not set when running workflows on
PRs from external contributors. Don't use remote caching when
the secret is not set.

For #31

Signed-off-by: Jay Conrod <jay@engflow.com>
